### PR TITLE
Fix user_hash collisions via session state

### DIFF
--- a/src/audio/audio_generator.py
+++ b/src/audio/audio_generator.py
@@ -5,6 +5,7 @@ import queue
 import logging
 import io
 import time
+import gradio as gr
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +97,7 @@ def update_audio(user_hash):
     while True:
         if user_hash not in sessions:
             time.sleep(0.5)
+            yield None, gr.update(value=user_hash)
             continue
         queue = sessions[user_hash]['queue']
         pcm_data = queue.get() # This is raw PCM audio bytes
@@ -125,4 +127,4 @@ def update_audio(user_hash):
             wf.setframerate(SAMPLE_RATE)
             wf.writeframes(pcm_data)
         wav_bytes = wav_buffer.getvalue()
-        yield wav_bytes
+        yield wav_bytes, gr.update(value=user_hash)

--- a/src/main.py
+++ b/src/main.py
@@ -38,7 +38,7 @@ async def return_to_constructor(user_hash: str):
         gr.update(visible=True),  # constructor_interface
         gr.update(visible=False),  # game_interface
         gr.update(visible=False),  # error_message
-        gr.update(value=new_hash),  # local_storage
+        gr.update(value=new_hash),  # user_id_state
     )
 
 
@@ -105,6 +105,7 @@ async def start_game_with_music(
     genre: str,
 ):
     """Start the game with custom settings and initialize music"""
+    user_hash_new = user_hash or str(uuid.uuid4())
     yield (
         gr.update(visible=True),  # loading indicator
         gr.update(),  # constructor_interface
@@ -114,11 +115,12 @@ async def start_game_with_music(
         gr.update(),
         gr.update(),  # game components unchanged
         gr.update(),  # custom choice unchanged
+        gr.update(value=user_hash_new),
     )
 
     # First, get the game interface updates
     result = await start_game_with_settings(
-        user_hash,
+        user_hash_new,
         setting_desc,
         char_name,
         char_age,
@@ -126,7 +128,7 @@ async def start_game_with_music(
         char_personality,
         genre,
     )
-    yield result
+    yield result + (gr.update(value=user_hash_new),)
 
 
 with gr.Blocks(
@@ -138,7 +140,7 @@ with gr.Blocks(
     with gr.Column(visible=False, elem_id="loading-indicator") as loading_indicator:
         gr.HTML("<div class='loading-text'>🚀 Starting your adventure...</div>")
 
-    local_storage = gr.BrowserState(str(uuid.uuid4()), "user_hash")
+    user_id_state = gr.State(None)
 
     # Constructor Interface (visible by default)
     with gr.Column(
@@ -315,7 +317,7 @@ with gr.Blocks(
     start_btn.click(
         fn=start_game_with_music,
         inputs=[
-            local_storage,
+            user_id_state,
             setting_description,
             char_name,
             char_age,
@@ -332,37 +334,38 @@ with gr.Blocks(
             game_image,
             game_choices,
             custom_choice,
+            user_id_state,
         ],
     )
 
     back_btn.click(
         fn=return_to_constructor,
-        inputs=[local_storage],
+        inputs=[user_id_state],
         outputs=[
             loading_indicator,
             constructor_interface,
             game_interface,
             error_message,
-            local_storage,
+            user_id_state,
         ],
     )
 
     game_choices.change(
         fn=update_scene,
-        inputs=[local_storage, game_choices],
+        inputs=[user_id_state, game_choices],
         outputs=[game_text, game_image, game_choices, custom_choice],
     )
 
     custom_choice.submit(
         fn=update_scene,
-        inputs=[local_storage, custom_choice],
+        inputs=[user_id_state, custom_choice],
         outputs=[game_text, game_image, game_choices, custom_choice],
     )
 
     demo.unload(cleanup_music_session)
     demo.load(
         fn=update_audio,
-        inputs=[local_storage],
+        inputs=[user_id_state],
         outputs=[audio_out],
     )
 

--- a/src/main.py
+++ b/src/main.py
@@ -45,7 +45,13 @@ async def return_to_constructor(user_hash: str):
 async def update_scene(user_hash: str, choice):
     logger.info(f"Updating scene with choice: {choice}")
     if not isinstance(choice, str):
-        return gr.update(), gr.update(), gr.update(), gr.update()
+        return (
+            gr.update(),
+            gr.update(),
+            gr.update(),
+            gr.update(),
+            gr.update(value=user_hash),
+        )
 
     result = await process_step(
         user_hash=user_hash,
@@ -64,6 +70,7 @@ async def update_scene(user_hash: str, choice):
             gr.update(value=ending_image),
             gr.Radio(choices=[], label="", value=None, visible=False),
             gr.update(value="", visible=False),
+            gr.update(value=user_hash),
         )
 
     scene = result["scene"]
@@ -77,6 +84,7 @@ async def update_scene(user_hash: str, choice):
             elem_classes=["choice-buttons"],
         ),
         gr.update(value=""),
+        gr.update(value=user_hash),
     )
 
 
@@ -353,20 +361,20 @@ with gr.Blocks(
     game_choices.change(
         fn=update_scene,
         inputs=[user_id_state, game_choices],
-        outputs=[game_text, game_image, game_choices, custom_choice],
+        outputs=[game_text, game_image, game_choices, custom_choice, user_id_state],
     )
 
     custom_choice.submit(
         fn=update_scene,
         inputs=[user_id_state, custom_choice],
-        outputs=[game_text, game_image, game_choices, custom_choice],
+        outputs=[game_text, game_image, game_choices, custom_choice, user_id_state],
     )
 
     demo.unload(cleanup_music_session)
     demo.load(
         fn=update_audio,
         inputs=[user_id_state],
-        outputs=[audio_out],
+        outputs=[audio_out, user_id_state],
     )
 
 demo.queue()


### PR DESCRIPTION
## Summary
- replace global `BrowserState` with per-session `State`
- generate UUID when starting a game if needed
- propagate `user_id_state` across all callbacks

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845ee62c2f883288cced18ccd9f6bc0