### PR TITLE
Add SQLAlchemy models and Alembic setup

### DIFF
--- a/highway/alembic.ini
+++ b/highway/alembic.ini
@@ -1,0 +1,147 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts.
+# this is typically a path given in POSIX (e.g. forward slashes)
+# format, relative to the token %(here)s which refers to the location of this
+# ini file
+script_location = %(here)s/alembic
+
+# template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
+# Uncomment the line below if you want the files to be prepended with date and time
+# see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file
+# for all available tokens
+# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.  for multiple paths, the path separator
+# is defined by "path_separator" below.
+prepend_sys_path = .
+
+
+# timezone to use when rendering the date within the migration file
+# as well as the filename.
+# If specified, requires the python>=3.9 or backports.zoneinfo library and tzdata library.
+# Any required deps can installed by adding `alembic[tz]` to the pip requirements
+# string value is passed to ZoneInfo()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; This defaults
+# to <script_location>/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path.
+# The path separator used here should be the separator specified by "path_separator"
+# below.
+# version_locations = %(here)s/bar:%(here)s/bat:%(here)s/alembic/versions
+
+# path_separator; This indicates what character is used to split lists of file
+# paths, including version_locations and prepend_sys_path within configparser
+# files such as alembic.ini.
+# The default rendered in new alembic.ini files is "os", which uses os.pathsep
+# to provide os-dependent path splitting.
+#
+# Note that in order to support legacy alembic.ini files, this default does NOT
+# take place if path_separator is not present in alembic.ini.  If this
+# option is omitted entirely, fallback logic is as follows:
+#
+# 1. Parsing of the version_locations option falls back to using the legacy
+#    "version_path_separator" key, which if absent then falls back to the legacy
+#    behavior of splitting on spaces and/or commas.
+# 2. Parsing of the prepend_sys_path option falls back to the legacy
+#    behavior of splitting on spaces, commas, or colons.
+#
+# Valid values for path_separator are:
+#
+# path_separator = :
+# path_separator = ;
+# path_separator = space
+# path_separator = newline
+#
+# Use os.pathsep. Default configuration used for new projects.
+path_separator = os
+
+# set to 'true' to search source files recursively
+# in each "version_locations" directory
+# new in Alembic version 1.10
+# recursive_version_locations = false
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+# database URL.  This is consumed by the user-maintained env.py script only.
+# other means of configuring database URLs may be customized within the env.py
+# file.
+sqlalchemy.url =
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks = black
+# black.type = console_scripts
+# black.entrypoint = black
+# black.options = -l 79 REVISION_SCRIPT_FILENAME
+
+# lint with attempts to fix using "ruff" - use the module runner, against the "ruff" module
+# hooks = ruff
+# ruff.type = module
+# ruff.module = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Alternatively, use the exec runner to execute a binary found on your PATH
+# hooks = ruff
+# ruff.type = exec
+# ruff.executable = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Logging configuration.  This is also consumed by the user-maintained
+# env.py script only.
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/highway/alembic/README
+++ b/highway/alembic/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/highway/alembic/env.py
+++ b/highway/alembic/env.py
@@ -1,0 +1,81 @@
+from logging.config import fileConfig
+
+from sqlalchemy import pool
+from sqlalchemy.ext.asyncio import async_engine_from_config
+
+from alembic import context
+from src.config import settings
+from src.models import Base
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+config.set_main_option("sqlalchemy.url", settings.database_url)
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# add your model's MetaData object here for 'autogenerate' support
+target_metadata = Base.metadata
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = settings.database_url
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        compare_type=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = async_engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    async def run_async_migrations() -> None:
+        async with connectable.connect() as connection:
+            await connection.run_sync(
+                lambda conn: context.configure(connection=conn, target_metadata=target_metadata, compare_type=True)
+            )
+            await connection.run_sync(context.run_migrations)
+
+    import asyncio
+    asyncio.run(run_async_migrations())
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/highway/alembic/script.py.mako
+++ b/highway/alembic/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, Sequence[str], None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    ${downgrades if downgrades else "pass"}

--- a/highway/alembic/versions/1b77e27f91fb_init.py
+++ b/highway/alembic/versions/1b77e27f91fb_init.py
@@ -1,0 +1,94 @@
+"""init
+
+Revision ID: 1b77e27f91fb
+Revises: 
+Create Date: 2025-07-23 15:01:26.248258
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = '1b77e27f91fb'
+down_revision: Union[str, Sequence[str], None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'users',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column('tg_id', sa.Text(), nullable=False),
+        sa.Column('username', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column('is_active', sa.Boolean(), nullable=False, server_default=sa.text('true')),
+        sa.UniqueConstraint('tg_id'),
+    )
+
+    op.create_table(
+        'game_templates',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column('user_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('setting_desc', sa.Text(), nullable=True),
+        sa.Column('char_name', sa.Text(), nullable=True),
+        sa.Column('char_age', sa.Text(), nullable=True),
+        sa.Column('char_background', sa.Text(), nullable=True),
+        sa.Column('char_personality', sa.Text(), nullable=True),
+        sa.Column('genre', sa.Text(), nullable=True),
+        sa.Column('is_public', sa.Boolean(), server_default=sa.text('false')),
+        sa.Column('created_at', sa.TIMESTAMP(timezone=True), nullable=False),
+    )
+
+    op.create_table(
+        'game_sessions',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column('user_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('template_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('game_templates.id'), nullable=True),
+        sa.Column('started_at', sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column('ended_at', sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column('share_code', postgresql.UUID(as_uuid=True), nullable=False),
+    )
+
+    op.create_table(
+        'scenes',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column('session_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('game_sessions.id'), nullable=False),
+        sa.Column('order_num', sa.Integer(), nullable=False),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.Column('generated_choices', postgresql.JSONB(), nullable=True),
+        sa.Column('image_path', sa.Text(), nullable=True),
+    )
+
+    op.create_table(
+        'choices',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column('scene_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('scenes.id'), nullable=False),
+        sa.Column('choice_text', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.TIMESTAMP(timezone=True), nullable=False),
+    )
+
+    op.create_table(
+        'subscriptions',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column('user_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('plan', sa.Text(), nullable=True),
+        sa.Column('started_at', sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column('expires_at', sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column('status', sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table('subscriptions')
+    op.drop_table('choices')
+    op.drop_table('scenes')
+    op.drop_table('game_sessions')
+    op.drop_table('game_templates')
+    op.drop_table('users')

--- a/highway/pyproject.toml
+++ b/highway/pyproject.toml
@@ -10,6 +10,9 @@ python = "^3.12"
 fastapi = "^0.116.0"
 uvicorn = {extras = ["standard"], version = "^0.35.0"}
 pydantic-settings = "^2.10.1"
+sqlalchemy = "^2.0"
+asyncpg = "^0.29"
+alembic = "^1.13"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/highway/src/config.py
+++ b/highway/src/config.py
@@ -23,5 +23,6 @@ class AppSettings(BaseAppSettings):
     tg_bot_token: SecretStr
     debug_mode: bool = False
     gradio_app_url: str
+    database_url: str
 
 settings = AppSettings()

--- a/highway/src/core/database.py
+++ b/highway/src/core/database.py
@@ -1,0 +1,15 @@
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from src.config import settings
+from src.models import Base
+
+engine = create_async_engine(settings.database_url, echo=False)
+AsyncSessionLocal = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+async def init_db() -> None:
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+async def get_session() -> AsyncSession:
+    async with AsyncSessionLocal() as session:
+        yield session

--- a/highway/src/models/__init__.py
+++ b/highway/src/models/__init__.py
@@ -1,0 +1,8 @@
+import uuid
+from sqlalchemy import MetaData
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    metadata = MetaData()
+

--- a/highway/src/models/choice.py
+++ b/highway/src/models/choice.py
@@ -1,0 +1,23 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import TIMESTAMP, Text, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from . import Base
+
+
+class Choice(Base):
+    __tablename__ = "choices"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    scene_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("scenes.id"))
+    choice_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), default=datetime.utcnow)
+
+    scene: Mapped["Scene"] = relationship(back_populates="choices")
+
+    def __repr__(self) -> str:
+        return f"Choice(id={self.id}, scene_id={self.scene_id})"
+

--- a/highway/src/models/game_session.py
+++ b/highway/src/models/game_session.py
@@ -1,0 +1,27 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import TIMESTAMP, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from . import Base
+
+
+class GameSession(Base):
+    __tablename__ = "game_sessions"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"))
+    template_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("game_templates.id"), nullable=True)
+    started_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), default=datetime.utcnow)
+    ended_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
+    share_code: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), default=uuid.uuid4)
+
+    user: Mapped["User"] = relationship(back_populates="sessions")
+    template: Mapped["GameTemplate" | None] = relationship(back_populates="sessions")
+    scenes: Mapped[list["Scene"]] = relationship(back_populates="session")
+
+    def __repr__(self) -> str:
+        return f"GameSession(id={self.id}, user_id={self.user_id})"
+

--- a/highway/src/models/game_template.py
+++ b/highway/src/models/game_template.py
@@ -1,0 +1,30 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, TIMESTAMP, Text, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from . import Base
+
+
+class GameTemplate(Base):
+    __tablename__ = "game_templates"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"))
+    setting_desc: Mapped[str | None] = mapped_column(Text, nullable=True)
+    char_name: Mapped[str | None] = mapped_column(Text, nullable=True)
+    char_age: Mapped[str | None] = mapped_column(Text, nullable=True)
+    char_background: Mapped[str | None] = mapped_column(Text, nullable=True)
+    char_personality: Mapped[str | None] = mapped_column(Text, nullable=True)
+    genre: Mapped[str | None] = mapped_column(Text, nullable=True)
+    is_public: Mapped[bool] = mapped_column(Boolean, default=False)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), default=datetime.utcnow)
+
+    user: Mapped["User"] = relationship(back_populates="templates")
+    sessions: Mapped[list["GameSession"]] = relationship(back_populates="template")
+
+    def __repr__(self) -> str:
+        return f"GameTemplate(id={self.id}, user_id={self.user_id})"
+

--- a/highway/src/models/scene.py
+++ b/highway/src/models/scene.py
@@ -1,0 +1,26 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import TIMESTAMP, Text, ForeignKey, Integer
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from . import Base
+
+
+class Scene(Base):
+    __tablename__ = "scenes"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    session_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("game_sessions.id"))
+    order_num: Mapped[int] = mapped_column(Integer)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    generated_choices: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    image_path: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    session: Mapped["GameSession"] = relationship(back_populates="scenes")
+    choices: Mapped[list["Choice"]] = relationship(back_populates="scene")
+
+    def __repr__(self) -> str:
+        return f"Scene(id={self.id}, session_id={self.session_id}, order_num={self.order_num})"
+

--- a/highway/src/models/subscription.py
+++ b/highway/src/models/subscription.py
@@ -1,0 +1,25 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import TIMESTAMP, Text, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from . import Base
+
+
+class Subscription(Base):
+    __tablename__ = "subscriptions"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"))
+    plan: Mapped[str | None] = mapped_column(Text, nullable=True)
+    started_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), default=datetime.utcnow)
+    expires_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
+    status: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    user: Mapped["User"] = relationship(back_populates="subscriptions")
+
+    def __repr__(self) -> str:
+        return f"Subscription(id={self.id}, user_id={self.user_id}, plan={self.plan})"
+

--- a/highway/src/models/user.py
+++ b/highway/src/models/user.py
@@ -1,0 +1,26 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, TIMESTAMP, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from . import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    tg_id: Mapped[str] = mapped_column(Text, unique=True)
+    username: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), default=datetime.utcnow)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+
+    templates: Mapped[list["GameTemplate"]] = relationship(back_populates="user")
+    sessions: Mapped[list["GameSession"]] = relationship(back_populates="user")
+    subscriptions: Mapped[list["Subscription"]] = relationship(back_populates="user")
+
+    def __repr__(self) -> str:
+        return f"User(id={self.id}, tg_id={self.tg_id})"
+


### PR DESCRIPTION
## Summary
- add SQLAlchemy/asyncpg/alembic dependencies
- implement database models using SQLAlchemy 2.0 async style
- configure async DB engine
- set up Alembic for migrations and create initial migration
- make `src` a package and extend settings with DB url

## Testing
- `pip install alembic sqlalchemy asyncpg`
- `pip install fastapi uvicorn`
- `pip install httpx`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_6880f832a3c88328855ae4853fb170c9