### PR TITLE
Fix Alembic schema for new user IDs

### DIFF
--- a/highway/alembic/versions/1b77e27f91fb_init.py
+++ b/highway/alembic/versions/1b77e27f91fb_init.py
@@ -23,8 +23,8 @@ def upgrade() -> None:
     """Upgrade schema."""
     op.create_table(
         'users',
-        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
-        sa.Column('tg_id', sa.Text(), nullable=False),
+        sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('tg_id', sa.BigInteger(), nullable=False),
         sa.Column('username', sa.Text(), nullable=True),
         sa.Column('created_at', sa.TIMESTAMP(timezone=True), nullable=False),
         sa.Column('is_active', sa.Boolean(), nullable=False, server_default=sa.text('true')),
@@ -34,7 +34,7 @@ def upgrade() -> None:
     op.create_table(
         'game_templates',
         sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
-        sa.Column('user_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id'), nullable=False),
         sa.Column('setting_desc', sa.Text(), nullable=True),
         sa.Column('char_name', sa.Text(), nullable=True),
         sa.Column('char_age', sa.Text(), nullable=True),
@@ -48,7 +48,7 @@ def upgrade() -> None:
     op.create_table(
         'game_sessions',
         sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
-        sa.Column('user_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id'), nullable=False),
         sa.Column('template_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('game_templates.id'), nullable=True),
         sa.Column('started_at', sa.TIMESTAMP(timezone=True), nullable=False),
         sa.Column('ended_at', sa.TIMESTAMP(timezone=True), nullable=True),
@@ -76,7 +76,7 @@ def upgrade() -> None:
     op.create_table(
         'subscriptions',
         sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
-        sa.Column('user_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id'), nullable=False),
         sa.Column('plan', sa.Text(), nullable=True),
         sa.Column('started_at', sa.TIMESTAMP(timezone=True), nullable=False),
         sa.Column('expires_at', sa.TIMESTAMP(timezone=True), nullable=True),

--- a/highway/src/models/game_session.py
+++ b/highway/src/models/game_session.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import TIMESTAMP, ForeignKey
+from sqlalchemy import TIMESTAMP, ForeignKey, Integer
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -12,7 +12,7 @@ class GameSession(Base):
     __tablename__ = "game_sessions"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"))
+    user_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"))
     template_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("game_templates.id"), nullable=True)
     started_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), default=datetime.utcnow)
     ended_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True), nullable=True)

--- a/highway/src/models/game_template.py
+++ b/highway/src/models/game_template.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import Boolean, TIMESTAMP, Text, ForeignKey
+from sqlalchemy import Boolean, TIMESTAMP, Text, ForeignKey, Integer
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -12,7 +12,7 @@ class GameTemplate(Base):
     __tablename__ = "game_templates"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"))
+    user_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"))
     setting_desc: Mapped[str | None] = mapped_column(Text, nullable=True)
     char_name: Mapped[str | None] = mapped_column(Text, nullable=True)
     char_age: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/highway/src/models/subscription.py
+++ b/highway/src/models/subscription.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import TIMESTAMP, Text, ForeignKey
+from sqlalchemy import TIMESTAMP, Text, ForeignKey, Integer
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -12,7 +12,7 @@ class Subscription(Base):
     __tablename__ = "subscriptions"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"))
+    user_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"))
     plan: Mapped[str | None] = mapped_column(Text, nullable=True)
     started_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), default=datetime.utcnow)
     expires_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True), nullable=True)


### PR DESCRIPTION
## Summary
- update Alembic init migration to create users.id as Integer and tg_id as BigInteger
- update relations in models to reference integer `users.id`

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_6883ad0b441c832890ea508d552328fc