### PR TITLE
Fix bot to backend URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 GEMINI_API_KEY=KEYS
 TG_BOT_TOKEN=xxx
+ADMIN_ID=1
+APP_URL=http://highway:8000
 DEBUG_MODE=True
 GRADIO_APP_URL=http://gradio:7860
 DATABASE_URL=postgresql+asyncpg://immuser:immpass@postgres:5432/immersiadb

--- a/bot/settings.py
+++ b/bot/settings.py
@@ -28,7 +28,7 @@ def get_settings(path: str):
         bots=Bots(
             bot_token=env.str("TG_BOT_TOKEN"),
             admin_id=env.int("ADMIN_ID"),
-            app_url=env.str("APP_URL", "http://app:8000"),
+            app_url=env.str("APP_URL", "http://highway:8000"),
             debug=env.bool("DEBUG", False)
         ),
     )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     environment:
       - TG_BOT_TOKEN=${TG_BOT_TOKEN}
       - ADMIN_ID=${ADMIN_ID}
-      - APP_URL=http://app:8000
+      - APP_URL=http://highway:8000
       - API_KEY=SECRET_TOKEN
     ports:
       - "25678:5678"


### PR DESCRIPTION
## Summary
- fix APP_URL in the docker-compose env to point to the backend service
- default bot settings to use the same backend URL
- document APP_URL and ADMIN_ID in the example env file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68854876ad1c8328a63e028d90448f44