### PR TITLE
Add aiogram game interface

### DIFF
--- a/bot/keyboards/inline.py
+++ b/bot/keyboards/inline.py
@@ -6,7 +6,43 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 
 def example_keyboard() -> InlineKeyboardMarkup:
     kb = InlineKeyboardBuilder()
-    kb.button(text='✅ Button1', callback_data='example:Button1')
-    kb.button(text='❌ Button2', callback_data='example:Button2')
+    kb.button(text="✅ Button1", callback_data="example:Button1")
+    kb.button(text="❌ Button2", callback_data="example:Button2")
     kb.adjust(2)
+    return kb.as_markup()
+
+
+def setup_keyboard(setting: str | None, character: str | None,
+                    genre: str | None) -> InlineKeyboardMarkup:
+    """Keyboard for the game setup step."""
+    kb = InlineKeyboardBuilder()
+    kb.button(text="Сеттинг", callback_data="edit:setting")
+    kb.button(text="Персонаж", callback_data="edit:character")
+    kb.button(text="Жанр", callback_data="edit:genre")
+    kb.button(text="Начать игру", callback_data="start_game")
+    kb.adjust(2, 2)
+    return kb.as_markup()
+
+
+def cancel_keyboard() -> InlineKeyboardMarkup:
+    kb = InlineKeyboardBuilder()
+    kb.button(text="Отмена", callback_data="cancel")
+    kb.adjust(1)
+    return kb.as_markup()
+
+
+def choices_keyboard(choices: Iterable[str]) -> InlineKeyboardMarkup:
+    kb = InlineKeyboardBuilder()
+    for choice in choices:
+        kb.button(text=choice, callback_data=f"choice:{choice}")
+    kb.adjust(1)
+    return kb.as_markup()
+
+
+def games_keyboard(games: Iterable[dict]) -> InlineKeyboardMarkup:
+    kb = InlineKeyboardBuilder()
+    for game in games:
+        title = game.get("title") or str(game.get("id"))
+        kb.button(text=title, callback_data=f"resume:{game['id']}")
+    kb.adjust(1)
     return kb.as_markup()

--- a/bot/main.py
+++ b/bot/main.py
@@ -3,7 +3,8 @@ from settings import settings
 from handlers import (
     admin,
     basic,
-    echo
+    echo,
+    game
 )
 import asyncio
 import logging
@@ -34,7 +35,8 @@ async def start():
     dp.include_routers(
         admin.router,
         basic.router,
-        echo.router
+        game.router,
+        echo.router,
     )
 
     try:

--- a/bot/utils/commands.py
+++ b/bot/utils/commands.py
@@ -4,16 +4,11 @@ from aiogram.types import BotCommand, BotCommandScopeDefault
 
 async def set_commands(bot: Bot):
     commands = [
-        BotCommand(command='start', description='Register user'),
-        BotCommand(command='help', description='Show help'),
-        BotCommand(command='create_template', description='Create template'),
-        BotCommand(command='list_templates', description='List templates'),
-        BotCommand(command='start_session', description='Start game session'),
-        BotCommand(command='make_choice', description='Send choice'),
-        BotCommand(command='history', description='Session history'),
-        BotCommand(command='plans', description='Show plans'),
-        BotCommand(command='subscribe', description='Subscribe plan'),
-        BotCommand(command='status', description='Subscription status'),
+        BotCommand(command="start", description="Register user"),
+        BotCommand(command="play", description="Create and play game"),
+        BotCommand(command="my_games", description="List my games"),
+        BotCommand(command="end_game", description="Finish current game"),
+        BotCommand(command="help", description="Show help"),
     ]
 
     await bot.set_my_commands(commands, BotCommandScopeDefault())

--- a/bot/utils/states.py
+++ b/bot/utils/states.py
@@ -3,3 +3,11 @@ from aiogram.fsm.state import StatesGroup, State
 
 class Basic(StatesGroup):
     basic = State()
+
+
+class GameSetup(StatesGroup):
+    waiting_input = State()
+
+
+class GamePlay(StatesGroup):
+    waiting_choice = State()


### PR DESCRIPTION
## Summary
- add a dynamic inline keyboard for the game flow
- implement GameSetup and GamePlay FSM states
- register new bot commands for game interaction
- implement new handlers for playing the game
- include game router in the bot entrypoint

## Testing
- `pytest -q` *(fails: SSL handshake failure)*

------
https://chatgpt.com/codex/tasks/task_e_6885f4301644832894115128e8e8be48