### PR TITLE
Improve code docs and add architecture overview

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -1,29 +1,34 @@
-from aiogram import Bot, Dispatcher
-from settings import settings
-from handlers import (
-    admin,
-    basic,
-    echo,
-    game
-)
+"""Telegram bot entry point."""
+
 import asyncio
 import logging
-from utils.commands import set_commands
+
+from aiogram import Bot, Dispatcher
+
+from handlers import admin, basic, echo, game
 from middlewares.typing import TypingMiddleware
+from settings import settings
+from utils.commands import set_commands
 
 logger = logging.getLogger(__name__)
 
 
 async def start_bot(bot: Bot):
+    """Notify admin that the bot has started."""
+
     await set_commands(bot)
-    await bot.send_message(settings.bots.admin_id, text='Bot started!')
+    await bot.send_message(settings.bots.admin_id, text="Bot started!")
 
 
 async def stop_bot(bot: Bot):
-    await bot.send_message(settings.bots.admin_id, text='Bot stopped!')
+    """Notify admin that the bot has stopped."""
+
+    await bot.send_message(settings.bots.admin_id, text="Bot stopped!")
 
 
 async def start():
+    """Initialize and start polling."""
+
     bot = Bot(token=settings.bots.bot_token)
     dp = Dispatcher()
 

--- a/bot/settings.py
+++ b/bot/settings.py
@@ -1,10 +1,17 @@
-from environs import Env
-from dataclasses import dataclass
-import logging
+"""Configuration loader for the bot."""
 
-logging.basicConfig(level=logging.INFO,
-                        format="%(asctime)s - [%(levelname)s] - %(name)s - "
-                        "(%(filename)s).%(funcName)s(%(lineno)d) -%(message)s")
+import logging
+from dataclasses import dataclass
+
+from environs import Env
+
+logging.basicConfig(
+    level=logging.INFO,
+    format=(
+        "%(asctime)s - [%(levelname)s] - %(name)s - "
+        "(%(filename)s).%(funcName)s(%(lineno)d) -%(message)s"
+    ),
+)
 
 
 @dataclass
@@ -20,7 +27,9 @@ class Settings:
     bots: Bots
 
 
-def get_settings(path: str):
+def get_settings(path: str) -> Settings:
+    """Load settings from a .env file."""
+
     env = Env()
     env.read_env(path)
 
@@ -34,5 +43,4 @@ def get_settings(path: str):
     )
 
 
-settings = get_settings('.env')
-print(settings)
+settings = get_settings(".env")

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -1,0 +1,64 @@
+# Backend Architecture
+
+This document provides an overview of the backend implemented in
+`highway` and its interaction with the Telegram bot in `bot`.
+
+## Application Layout
+
+- **highway/src/main.py** – FastAPI application entry point. Routers from
+  all API modules are registered here. CORS middleware is enabled and
+  debugging via `debugpy` is supported when `debug_mode` is on.
+- **highway/src/api/** – REST API divided into logical modules:
+  - `auth` – registration and profile endpoints.
+  - `templates` – CRUD for game templates.
+  - `sessions` – management of game sessions and scene generation.
+  - `scenes` – operations with individual scenes.
+  - `payments` – simple subscription endpoints.
+- **highway/src/auth/** – helper functions for verifying Telegram
+  authentication data.
+- **highway/src/core/** – database initialization and session provider.
+- **highway/src/models/** – SQLAlchemy models describing persistent
+  entities such as `User`, `GameTemplate`, and `GameSession`.
+- **bot/** – aiogram based Telegram bot. Polls messages and delegates
+  commands to handlers.
+
+## External Dependencies
+
+- **FastAPI** – main web framework.
+- **SQLAlchemy** – asynchronous ORM for PostgreSQL/SQLite.
+- **LangChain / Google Generative AI** – used for game scene generation.
+- **Aiogram** – framework for building the Telegram bot.
+
+## API Endpoints
+
+Below is a brief summary of the public endpoints provided by FastAPI.
+
+| Method | Path                                   | Description                          |
+|-------|----------------------------------------|--------------------------------------|
+| GET   | `/health-check`                        | Liveness probe.                      |
+| POST  | `/auth/session`                        | Validate WebApp init data and set a cookie. |
+| POST  | `/api/v1/auth/register`                | Register a Telegram user.            |
+| GET   | `/api/v1/users/me`                     | Current user info.                   |
+| POST  | `/api/v1/templates`                    | Create a game template.              |
+| GET   | `/api/v1/templates`                    | List user templates.                 |
+| GET   | `/api/v1/templates/{id}`               | Fetch a template.                    |
+| POST  | `/api/v1/templates/{id}/share`         | Make a template public.              |
+| GET   | `/api/v1/templates/shared/{code}`      | Retrieve shared template.            |
+| POST  | `/api/v1/sessions`                     | Start a game session.                |
+| GET   | `/api/v1/sessions/{id}`                | Get current scene.                   |
+| POST  | `/api/v1/sessions/{id}/choice`         | Submit choice and generate next scene. |
+| POST  | `/api/v1/sessions/{id}/scenes`         | Create additional scene.             |
+| GET   | `/api/v1/sessions/{id}/history`        | Full session history.                |
+| DELETE| `/api/v1/sessions/{id}`                | Remove game session.                 |
+| GET   | `/api/v1/plans`                        | List available subscription plans.   |
+| POST  | `/api/v1/subscribe`                    | Start subscription process.          |
+| GET   | `/api/v1/subscription/status`          | Current subscription status.         |
+
+## Telegram Bot Integration
+
+The bot located in the `bot` directory communicates with the API by
+sending HTTP requests using `httpx`. User authentication is performed
+via Telegram WebApp `initData` which is later stored in a cookie by the
+`/auth/session` endpoint. The bot uses custom keyboards and finite state
+machines for a simple interactive adventure game.
+

--- a/highway/src/main.py
+++ b/highway/src/main.py
@@ -1,4 +1,8 @@
+"""Application entry point."""
+
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
 from src.config import settings
 from src.routes.gradio_proxy import gradio_router
 from src.routes.auth import auth_router
@@ -7,8 +11,8 @@ from src.api.templates.router import router as templates_router
 from src.api.sessions.router import router as sessions_router
 from src.api.scenes.router import router as scenes_router
 from src.api.payments.router import router as payments_router
+
 import logging
-from fastapi.middleware.cors import CORSMiddleware
 
 logger = logging.getLogger(__name__)    
 
@@ -38,9 +42,13 @@ app.include_router(scenes_router)
 app.include_router(payments_router)
 
 @app.get("/")
-def read_root():
+def read_root() -> dict:
+    """Return a simple greeting used for smoke tests."""
+
     return {"Hello": "World"}
 
 @app.get("/health-check")
-def health_check():
-    return {"status": "ok"} 
+def health_check() -> dict:
+    """Endpoint for liveness probes."""
+
+    return {"status": "ok"}

--- a/highway/src/routes/auth.py
+++ b/highway/src/routes/auth.py
@@ -1,33 +1,34 @@
+"""Authentication helpers for Telegram WebApp."""
+
 from fastapi import APIRouter, Depends, Response
-from src.auth.tg_auth import verify_tg_data
+
 import json
+
+from src.auth.tg_auth import verify_tg_data
 
 auth_router = APIRouter(prefix="/auth", tags=["auth"])
 
 
 @auth_router.post("/session")
-async def create_session(response: Response, user_data: dict = Depends(verify_tg_data)):
-    """
-    Authenticates the user with their Telegram initData and sets a session cookie.
-    The frontend should call this endpoint once when the app loads.
-    """
-    # The user_data is already validated by the verify_tg_data dependency.
-    # We can use the user's ID as the session value.
+async def create_session(
+    response: Response,
+    user_data: dict = Depends(verify_tg_data),
+) -> dict:
+    """Authenticate user and set a secure cookie."""
+
     user_info = json.loads(user_data.get("user", "{}"))
     user_id = user_info.get("id")
 
     if not user_id:
         return {"status": "error", "message": "User not found in initData"}
 
-    # Set a secure, HttpOnly cookie to maintain the session.
-    # The browser will automatically send this cookie on subsequent requests.
     response.set_cookie(
         key="session_id",
         value=str(user_id),
         httponly=True,
         max_age=3600,
-        secure=True,          # Only send over HTTPS
-        samesite="strict",      # Required for cross-site contexts like iframes
+        secure=True,
+        samesite="strict",
         path="/api",
     )
-    return {"status": "ok"} 
+    return {"status": "ok"}

--- a/highway/src/routes/gradio_proxy.py
+++ b/highway/src/routes/gradio_proxy.py
@@ -1,20 +1,32 @@
+"""Reverse proxy to forward requests to the Gradio service."""
+
 from fastapi import APIRouter, Depends
-from src.auth.tg_auth import authenticated_user
-import httpx
-from src.config import settings
+from starlette.background import BackgroundTask
 from starlette.requests import Request
 from starlette.responses import StreamingResponse
-from starlette.background import BackgroundTask
+
+import httpx
+
+from src.auth.tg_auth import authenticated_user
+from src.config import settings
 
 gradio_router = APIRouter(prefix="/gradio", tags=["gradio"])
 
 client = httpx.AsyncClient(base_url=settings.gradio_app_url)
 
 
-@gradio_router.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"], dependencies=[Depends(authenticated_user)])
-async def gradio_proxy(request: Request):
-    url = httpx.URL(path=request.url.path.replace("/gradio/", "/"),
-                    query=request.url.query.encode("utf-8"))
+@gradio_router.api_route(
+    "/{path:path}",
+    methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"],
+    dependencies=[Depends(authenticated_user)],
+)
+async def gradio_proxy(request: Request) -> StreamingResponse:
+    """Forward any request under /gradio/* to the Gradio backend."""
+
+    url = httpx.URL(
+        path=request.url.path.replace("/gradio/", "/"),
+        query=request.url.query.encode("utf-8"),
+    )
     # Convert headers to a mutable dict and remove Host header
     headers = dict(request.headers.raw)
     headers.pop(b"host", None)


### PR DESCRIPTION
## Summary
- refine FastAPI entry point and routes
- clean up Telegram bot startup code and configuration
- document backend architecture

## Testing
- `pytest -q` *(fails: network access required for external services)*

------
https://chatgpt.com/codex/tasks/task_e_68862b8112b48328b5c432fe67c77db5