### PR TITLE
Refine bot command messages

### DIFF
--- a/bot/handlers/basic.py
+++ b/bot/handlers/basic.py
@@ -54,7 +54,12 @@ async def start_command(message: Message):
         "Authorization": f"tma {init_data}"
     }
 
-    welcome = f"👋 Hi, <b>{message.from_user.first_name}</b>!"
+    welcome = (
+        f"👋 Привет, <b>{message.from_user.first_name}</b>!\n"
+        "Добро пожаловать в <b>Immersia GameHub</b> — здесь вы можете \"
+        "создавать собственные интерактивные истории.\n"
+        "Отправьте <b>/new_game</b>, чтобы начать приключение."
+    )
     await message.answer(welcome, parse_mode=ParseMode.HTML)
 
 
@@ -62,7 +67,13 @@ async def start_command(message: Message):
 async def help_command(message: Message):
     """Show help message to the user."""
 
-    help_message = "ℹ️ <b>INFO</b>"
+    help_message = (
+        "ℹ️ <b>Помощь</b>\n\n"
+        "<b>/new_game</b> — создать новую игру\n"
+        "<b>/my_games</b> — список ваших активных игр\n"
+        "<b>/end_game</b> — завершить текущую сессию\n"
+        "<b>/help</b> — показать это сообщение"
+    )
     await message.answer(
         help_message,
         parse_mode=ParseMode.HTML,

--- a/bot/handlers/game.py
+++ b/bot/handlers/game.py
@@ -101,7 +101,7 @@ def _get_headers(uid: int) -> dict | None:
     return user_headers.get(uid)
 
 
-@router.message(Command("play"))
+@router.message(Command(commands=["play", "new_game"]))
 async def play_cmd(message: Message, state: FSMContext):
     """Begin game setup by sending initial template."""
 
@@ -333,10 +333,14 @@ async def my_games_cmd(message: Message):
 
     games = active_sessions.get(message.from_user.id)
     if not games:
-        await message.answer("Нет активных игр")
+        await message.answer(
+            "У вас пока нет активных игр. Используйте /new_game, чтобы начать."
+        )
         return
     kb = games_keyboard(games)
-    await message.answer("Ваши игры:", reply_markup=kb)
+    await message.answer(
+        "Вы можете продолжить одну из текущих игр:", reply_markup=kb
+    )
 
 
 @router.callback_query(F.data.startswith("resume:"))

--- a/bot/utils/commands.py
+++ b/bot/utils/commands.py
@@ -8,11 +8,11 @@ async def set_commands(bot: Bot) -> None:
     """Register default commands for the bot."""
 
     commands = [
-        BotCommand(command="start", description="Register user"),
-        BotCommand(command="play", description="Create and play game"),
-        BotCommand(command="my_games", description="List my games"),
-        BotCommand(command="end_game", description="Finish current game"),
-        BotCommand(command="help", description="Show help"),
+        BotCommand(command="start", description="Регистрация"),
+        BotCommand(command="new_game", description="Создать игру"),
+        BotCommand(command="my_games", description="Мои игры"),
+        BotCommand(command="end_game", description="Завершить игру"),
+        BotCommand(command="help", description="Помощь"),
     ]
 
     await bot.set_my_commands(commands, BotCommandScopeDefault())


### PR DESCRIPTION
## Summary
- add Russian welcome and help text
- respond to `/new_game` as an alias for `/play`
- improve `/my_games` responses
- register `/new_game` command

## Testing
- `pytest -q` *(fails: SSL handshake to external service)*

------
https://chatgpt.com/codex/tasks/task_e_688634aaf7c883289348d72c0a5f9a8a