### PR TITLE
Implement preset game templates

### DIFF
--- a/highway/alembic/versions/760e50129cab_add_template_extras.py
+++ b/highway/alembic/versions/760e50129cab_add_template_extras.py
@@ -1,0 +1,58 @@
+"""add template extras
+
+Revision ID: 760e50129cab
+Revises: 1b77e27f91fb
+Create Date: 2025-07-28 23:15:48.709659
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '760e50129cab'
+down_revision: Union[str, Sequence[str], None] = '1b77e27f91fb'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table("game_templates") as batch:
+        batch.alter_column("user_id", existing_type=sa.Integer(), nullable=True)
+        batch.add_column(sa.Column("title", sa.Text(), nullable=True))
+        batch.add_column(sa.Column("story_frame", sa.dialects.postgresql.JSONB(), nullable=True))
+        batch.add_column(
+            sa.Column(
+                "is_free",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("false"),
+            )
+        )
+        batch.add_column(
+            sa.Column(
+                "is_preset",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("false"),
+            )
+        )
+
+    with op.batch_alter_table("game_sessions") as batch:
+        batch.add_column(sa.Column("story_frame", sa.dialects.postgresql.JSONB(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("game_sessions") as batch:
+        batch.drop_column("story_frame")
+
+    with op.batch_alter_table("game_templates") as batch:
+        batch.drop_column("is_preset")
+        batch.drop_column("is_free")
+        batch.drop_column("story_frame")
+        batch.drop_column("title")
+        batch.alter_column("user_id", existing_type=sa.Integer(), nullable=False)

--- a/highway/src/api/sessions/router.py
+++ b/highway/src/api/sessions/router.py
@@ -45,6 +45,7 @@ async def create_session(
         id=str(session_obj.id),
         started_at=session_obj.started_at,
         share_code=str(session_obj.share_code),
+        story_frame=session_obj.story_frame,
     )
 
 

--- a/highway/src/api/sessions/schemas.py
+++ b/highway/src/api/sessions/schemas.py
@@ -10,6 +10,7 @@ class SessionOut(BaseModel):
     id: str
     started_at: datetime
     share_code: str
+    story_frame: dict | None = None
 
     class Config:
         from_attributes = True

--- a/highway/src/api/templates/schemas.py
+++ b/highway/src/api/templates/schemas.py
@@ -3,12 +3,16 @@ from pydantic import BaseModel
 
 
 class TemplateCreate(BaseModel):
+    title: str | None = None
     setting_desc: str | None = None
     char_name: str | None = None
     char_age: str | None = None
     char_background: str | None = None
     char_personality: str | None = None
     genre: str | None = None
+    story_frame: dict | None = None
+    is_free: bool | None = None
+    is_preset: bool | None = None
 
 
 class TemplateOut(TemplateCreate):

--- a/highway/src/config.py
+++ b/highway/src/config.py
@@ -29,6 +29,7 @@ class AppSettings(BaseAppSettings):
     temperature: float = 0.5
     pregenerate_next_scene: bool = True
     request_timeout: int = 20
+    admin_ids: list[int] = []
 
 
 settings = AppSettings()

--- a/highway/src/game/agent/llm_graph.py
+++ b/highway/src/game/agent/llm_graph.py
@@ -49,14 +49,16 @@ def route_step(state: GraphState) -> str:
 
 async def node_init_game(state: GraphState) -> GraphState:
     logger.debug("[Graph] node_init_game state: %s", state)
-    await generate_story_frame.ainvoke(
-        {
-            "user_hash": state.user_hash,
-            "setting": state.setting,
-            "character": state.character,
-            "genre": state.genre,
-        }
-    )
+    user_state = await get_user_state(state.user_hash)
+    if not user_state.story_frame:
+        await generate_story_frame.ainvoke(
+            {
+                "user_hash": state.user_hash,
+                "setting": state.setting,
+                "character": state.character,
+                "genre": state.genre,
+            }
+        )
     first_scene = await generate_scene.ainvoke(
         {"user_hash": state.user_hash, "last_choice": "start"}
     )

--- a/highway/src/models/game_session.py
+++ b/highway/src/models/game_session.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import TIMESTAMP, ForeignKey, Integer
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from . import Base
@@ -34,6 +34,7 @@ class GameSession(Base):
         UUID(as_uuid=True),
         default=uuid.uuid4,
     )
+    story_frame: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
 
     user: Mapped["User"] = relationship(back_populates="sessions")
     template: Mapped["GameTemplate | None"] = relationship(

--- a/highway/src/models/game_template.py
+++ b/highway/src/models/game_template.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import Boolean, TIMESTAMP, Text, ForeignKey, Integer
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from . import Base
@@ -20,7 +20,13 @@ class GameTemplate(Base):
         primary_key=True,
         default=uuid.uuid4,
     )
-    user_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"))
+    user_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("users.id"), nullable=True
+    )
+    title: Mapped[str | None] = mapped_column(Text, nullable=True)
+    story_frame: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    is_free: Mapped[bool] = mapped_column(Boolean, default=False)
+    is_preset: Mapped[bool] = mapped_column(Boolean, default=False)
     setting_desc: Mapped[str | None] = mapped_column(Text, nullable=True)
     char_name: Mapped[str | None] = mapped_column(Text, nullable=True)
     char_age: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/miniapp/src/api/stories.ts
+++ b/miniapp/src/api/stories.ts
@@ -9,25 +9,20 @@ export interface StoryResponse {
   stories: StoryDTO[];
 }
 
-// Temporary mock implementation until backend is ready
-export async function getStories(_realmId: string): Promise<StoryResponse> {
-  // For demo, ignoring realmId and returning generic content
+import { API_URL } from "./common";
+
+export async function getStories(): Promise<StoryResponse> {
+  const resp = await fetch(`${API_URL}/templates/preset`);
+  if (!resp.ok) {
+    throw new Error("Failed to fetch stories");
+  }
+  const data = await resp.json();
   return {
-    stories: [
-      {
-        id: "hot-neighbor",
-        title: "Hot Neighbor",
-        description: "Your floor's hot neighbor has nowhere to sleep!",
-        imageUrl:
-          "https://www.abilitybathedevon.co.uk/wp-content/uploads/2023/11/image-1-1.png",
-      },
-      {
-        id: "stepmom-shower",
-        title: "Stepmom Shower",
-        description: "Your stepmom forgot to lock the bathroom door...",
-        imageUrl:
-          "https://www.abilitybathedevon.co.uk/wp-content/uploads/2023/11/image-1-1.png",
-      },
-    ],
+    stories: data.map((t: any) => ({
+      id: t.id,
+      title: t.title,
+      description: t.setting_desc,
+      imageUrl: "",
+    })),
   };
-} 
+}


### PR DESCRIPTION
## Summary
- add new columns for `GameTemplate` and `GameSession`
- create alembic migration
- expose preset template APIs
- support admin bulk upload
- persist/restore story frames in sessions
- skip story frame generation when frame exists
- extend frontend stories API

## Testing
- `PYTHONPATH=. TG_BOT_TOKEN=dummy DATABASE_URL=sqlite+aiosqlite:// pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688802c25ba8832886ded515be8e0f19