### PR TITLE
Fix model import order for SQLAlchemy

### DIFF
--- a/highway/src/models/__init__.py
+++ b/highway/src/models/__init__.py
@@ -10,6 +10,18 @@ class Base(DeclarativeBase):
     metadata = MetaData()
 
 # Import models so Alembic can discover them
+# Import all models so that SQLAlchemy can resolve string based relationships
+# during mapper configuration. Failing to import a model before it is referenced
+# in another model's ``relationship`` definition results in ``InvalidRequestError``
+# when SQLAlchemy tries to resolve the class name. Importing them here ensures
+# they are registered with the declarative registry on startup.
+
+from .user import User  # noqa: F401
 from .world import World  # noqa: F401
 from .story import Story  # noqa: F401
+from .game_template import GameTemplate  # noqa: F401
+from .game_session import GameSession  # noqa: F401
+from .scene import Scene  # noqa: F401
+from .choice import Choice  # noqa: F401
+from .subscription import Subscription  # noqa: F401
 


### PR DESCRIPTION
## Summary
- ensure all ORM models are imported when SQLAlchemy configures mappings

## Testing
- `pip install aiosqlite`
- `PYTHONPATH=GameHub/highway pytest GameHub/highway/tests/test_main.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688a978124448328ac0ff4e9a24f89ac