### PR TITLE
Fix async loading of related models

### DIFF
--- a/highway/src/api/scenes/router.py
+++ b/highway/src/api/scenes/router.py
@@ -9,6 +9,7 @@ from src.auth.tg_auth import authenticated_user
 from src.core.database import get_session
 from src.models.scene import Scene
 from src.models.game_session import GameSession
+from src.models.story import Story
 from .schemas import SceneCreate, SceneOut, scene_to_out
 from .scene_service import create_and_store_scene
 from src.api.utils import resolve_user_id
@@ -36,10 +37,16 @@ async def generate_scene(
     user_id = await resolve_user_id(db, user_data)
     if res.user_id != user_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
+    story = None
+    if res.story_id:
+        story = await db.get(Story, res.story_id)
+        if story:
+            await db.refresh(story, ["world"])
     scene = await create_and_store_scene(
         db,
         res,
         payload.choice_text if payload else None,
+        story,
     )
     return scene_to_out(scene)
 

--- a/highway/src/api/sessions/router.py
+++ b/highway/src/api/sessions/router.py
@@ -38,7 +38,8 @@ async def create_session(
     if story_id:
         story = await db.get(Story, story_id)
         if story:
-            await create_and_store_scene(db, session_obj, None)
+            await db.refresh(story, ["world"])
+            await create_and_store_scene(db, session_obj, None, story)
 
     return SessionOut(
         id=str(session_obj.id),


### PR DESCRIPTION
## Summary
- resolve `MissingGreenlet` during session creation
- preload story with world relation before generating the first scene

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b869b3c488328a9c759499f15072f