### PR TITLE
Add language selection and preset stories

### DIFF
--- a/bot/keyboards/inline.py
+++ b/bot/keyboards/inline.py
@@ -2,7 +2,7 @@
 
 from typing import Iterable
 
-from aiogram.types import InlineKeyboardMarkup
+from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 
 
@@ -57,4 +57,27 @@ def games_keyboard(games: Iterable[dict]) -> InlineKeyboardMarkup:
         title = game.get("title") or str(game.get("id"))
         kb.button(text=title, callback_data=f"resume:{game['id']}")
     kb.adjust(1)
+    return kb.as_markup()
+
+
+def language_keyboard() -> InlineKeyboardMarkup:
+    kb = InlineKeyboardBuilder()
+    kb.button(text="Русский", callback_data="lang:ru")
+    kb.button(text="English", callback_data="lang:en")
+    kb.adjust(2)
+    return kb.as_markup()
+
+
+def stories_keyboard(stories: Iterable[dict], app_url: str) -> InlineKeyboardMarkup:
+    kb = InlineKeyboardBuilder()
+    for story in stories:
+        kb.button(text=story.get("title"), callback_data=f"preset:{story['id']}")
+    kb.adjust(2)
+    kb.row(InlineKeyboardButton(text="✨ Откройте все истории", url=app_url))
+    return kb.as_markup()
+
+
+def open_app_keyboard(app_url: str) -> InlineKeyboardMarkup:
+    kb = InlineKeyboardBuilder()
+    kb.row(InlineKeyboardButton(text="✨ Откройте веб-приложение", url=app_url))
     return kb.as_markup()

--- a/bot/utils/commands.py
+++ b/bot/utils/commands.py
@@ -9,7 +9,7 @@ async def set_commands(bot: Bot) -> None:
 
     commands = [
         BotCommand(command="start", description="Регистрация"),
-        BotCommand(command="new_game", description="Создать игру"),
+        BotCommand(command="my_game", description="Создать игру"),
         BotCommand(command="my_games", description="Мои игры"),
         BotCommand(command="end_game", description="Завершить игру"),
         BotCommand(command="help", description="Помощь"),

--- a/bot/utils/presets.py
+++ b/bot/utils/presets.py
@@ -1,0 +1,28 @@
+from keyboards.inline import stories_keyboard
+from settings import settings
+import httpx
+
+http_client = httpx.AsyncClient(base_url=settings.bots.app_url, timeout=10.0)
+
+
+async def show_presets(chat_id: int, bot, headers: dict) -> None:
+    resp = await http_client.get("/api/v1/stories/preset", headers=headers)
+    if resp.status_code != 200:
+        await bot.send_message(chat_id, "Нет доступных историй")
+        return
+    stories = resp.json()
+    emojis = {
+        "Horror": "😱",
+        "Romantic": "😍",
+        "Adventure": "🏕️",
+        "Fantasy": "🧙",
+        "Sci-Fi": "🤖",
+    }
+    lines = ["Выберите вашу историю:"]
+    for s in stories:
+        emoji = emojis.get(s.get("genre"), "🎲")
+        lines.append(f"{emoji} [{s.get('genre')}] {s.get('title')}")
+    text = "\n".join(lines)
+    kb = stories_keyboard(stories, settings.bots.app_url)
+    await bot.send_message(chat_id, text, reply_markup=kb)
+

--- a/highway/alembic/versions/3b9d7d573b0a_add_user_language.py
+++ b/highway/alembic/versions/3b9d7d573b0a_add_user_language.py
@@ -1,0 +1,28 @@
+"""add user language field
+
+Revision ID: 3b9d7d573b0a
+Revises: df5e3b8d1a2c
+Create Date: 2025-08-01 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = '3b9d7d573b0a'
+down_revision: Union[str, Sequence[str], None] = 'df5e3b8d1a2c'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('users') as batch:
+        batch.add_column(sa.Column('language', sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('users') as batch:
+        batch.drop_column('language')
+

--- a/highway/src/api/stories/router.py
+++ b/highway/src/api/stories/router.py
@@ -52,6 +52,15 @@ async def list_stories(world_id: str, db: AsyncSession = Depends(get_session)) -
     return [StoryOut.from_orm(s) for s in stories]
 
 
+@router.get("/stories/preset", response_model=list[StoryOut])
+async def list_preset_stories(db: AsyncSession = Depends(get_session)) -> list[StoryOut]:
+    res = await db.execute(
+        select(Story).where(Story.is_preset.is_(True), Story.is_free.is_(True))
+    )
+    stories = list(res.scalars())
+    return [StoryOut.from_orm(s) for s in stories]
+
+
 @router.get("/stories/{story_id}", response_model=StoryOut)
 async def get_story(story_id: str, db: AsyncSession = Depends(get_session)) -> StoryOut:
     obj = await db.get(Story, uuid.UUID(story_id))

--- a/highway/src/models/user.py
+++ b/highway/src/models/user.py
@@ -22,6 +22,7 @@ class User(Base):
         index=True,
     )
     username: Mapped[str | None] = mapped_column(Text, nullable=True)
+    language: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True),
         default=datetime.utcnow,


### PR DESCRIPTION
## Summary
- allow storing users' language in the backend
- provide endpoint to update profile and list preset stories
- add language choice and preset story flow to Telegram bot
- require Pro subscription for custom games
- expose helper keyboards

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b8d6954908328a9d0110f62e36132