### PR TITLE
Fix start command issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@ GEMINI_API_KEY=KEYS
 TG_BOT_TOKEN=xxx
 ADMIN_ID=1,2
 APP_URL=http://highway:8000
+WEB_URL=https://www.immersia.fun
 DEBUG_MODE=True
 DATABASE_URL=postgresql+asyncpg://immuser:immpass@postgres:5432/immersiadb
 POSTGRES_PASSWORD=pass

--- a/bot/handlers/game.py
+++ b/bot/handlers/game.py
@@ -136,7 +136,7 @@ async def play_cmd(message: Message, state: FSMContext):
     if not await _has_pro(message.from_user.id):
         await message.answer(
             "Создай собственную историю в веб-приложении",
-            reply_markup=open_app_keyboard(settings.bots.app_url),
+            reply_markup=open_app_keyboard(settings.bots.web_url),
         )
         return
 

--- a/bot/keyboards/inline.py
+++ b/bot/keyboards/inline.py
@@ -68,16 +68,16 @@ def language_keyboard() -> InlineKeyboardMarkup:
     return kb.as_markup()
 
 
-def stories_keyboard(stories: Iterable[dict], app_url: str) -> InlineKeyboardMarkup:
+def stories_keyboard(stories: Iterable[dict], web_url: str) -> InlineKeyboardMarkup:
     kb = InlineKeyboardBuilder()
     for story in stories:
         kb.button(text=story.get("title"), callback_data=f"preset:{story['id']}")
     kb.adjust(2)
-    kb.row(InlineKeyboardButton(text="✨ Откройте все истории", url=app_url))
+    kb.row(InlineKeyboardButton(text="✨ Откройте все истории", url=web_url))
     return kb.as_markup()
 
 
-def open_app_keyboard(app_url: str) -> InlineKeyboardMarkup:
+def open_app_keyboard(web_url: str) -> InlineKeyboardMarkup:
     kb = InlineKeyboardBuilder()
-    kb.row(InlineKeyboardButton(text="✨ Откройте веб-приложение", url=app_url))
+    kb.row(InlineKeyboardButton(text="✨ Откройте веб-приложение", url=web_url))
     return kb.as_markup()

--- a/bot/settings.py
+++ b/bot/settings.py
@@ -22,6 +22,7 @@ class Bots:
     bot_token: str
     admin_id: List[int]
     app_url: str
+    web_url: str
     debug: bool
 
 
@@ -43,6 +44,7 @@ def get_settings(path: str) -> Settings:
             bot_token=env.str("TG_BOT_TOKEN"),
             admin_id=[int(x) for x in env.list("ADMIN_ID")],
             app_url=env.str("APP_URL", "http://highway:8000"),
+            web_url=env.str("WEB_URL", "https://www.immersia.fun/"),
             debug=env.bool("DEBUG", False)
         ),
     )

--- a/bot/utils/presets.py
+++ b/bot/utils/presets.py
@@ -23,6 +23,6 @@ async def show_presets(chat_id: int, bot, headers: dict) -> None:
         emoji = emojis.get(s.get("genre"), "🎲")
         lines.append(f"{emoji} [{s.get('genre')}] {s.get('title')}")
     text = "\n".join(lines)
-    kb = stories_keyboard(stories, settings.bots.app_url)
+    kb = stories_keyboard(stories, settings.bots.web_url)
     await bot.send_message(chat_id, text, reply_markup=kb)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - TG_BOT_TOKEN=${TG_BOT_TOKEN}
       - ADMIN_ID=${ADMIN_ID}
       - APP_URL=http://highway:8000
+      - WEB_URL=${WEB_URL}
       - API_KEY=SECRET_TOKEN
     ports:
       - "25678:5678"

--- a/highway/src/api/auth/router.py
+++ b/highway/src/api/auth/router.py
@@ -69,22 +69,22 @@ async def get_me(
 
     tg_id = None
     if "user_id" in user_data:
-        tg_id = str(user_data["user_id"])
+        tg_id = user_data["user_id"]
     else:
         if isinstance(user_data.get("user"), str):
             try:
-                tg_id = str(json.loads(user_data["user"]).get("id"))
+                tg_id = json.loads(user_data["user"]).get("id")
             except Exception:
                 tg_id = None
         if tg_id is None:
             raw_id = user_data.get("id")
-            tg_id = str(raw_id) if raw_id is not None else None
-    if not tg_id:
+            tg_id = raw_id if raw_id is not None else None
+    if tg_id is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="User not found",
         )
-    res = await session.execute(select(User).where(User.tg_id == tg_id))
+    res = await session.execute(select(User).where(User.tg_id == int(tg_id)))
     user = res.scalar_one_or_none()
     if not user:
         raise HTTPException(
@@ -106,19 +106,19 @@ async def update_me(
 ) -> User:
     tg_id = None
     if "user_id" in user_data:
-        tg_id = str(user_data["user_id"])
+        tg_id = user_data["user_id"]
     else:
         if isinstance(user_data.get("user"), str):
             try:
-                tg_id = str(json.loads(user_data["user"]).get("id"))
+                tg_id = json.loads(user_data["user"]).get("id")
             except Exception:
                 tg_id = None
         if tg_id is None:
             raw_id = user_data.get("id")
-            tg_id = str(raw_id) if raw_id is not None else None
-    if not tg_id:
+            tg_id = raw_id if raw_id is not None else None
+    if tg_id is None:
         raise HTTPException(status_code=404, detail="User not found")
-    res = await session.execute(select(User).where(User.tg_id == tg_id))
+    res = await session.execute(select(User).where(User.tg_id == int(tg_id)))
     user = res.scalar_one_or_none()
     if not user:
         raise HTTPException(status_code=404, detail="User not found")


### PR DESCRIPTION
## Summary
- add WEB_URL environment variable and use it in inline keyboards
- handle numeric tg_id in auth endpoints
- update docker-compose and example env file
- ensure start command uses external URL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bb7cb1f3c83288d6b71094132d1d0