### PR TITLE
Fix preset sessions and subscription check

### DIFF
--- a/bot/handlers/game.py
+++ b/bot/handlers/game.py
@@ -124,7 +124,7 @@ async def _has_pro(uid: int) -> bool:
     if resp.status_code != 200:
         return False
     data = resp.json()
-    return data.get("status") == "active"
+    return data.get("status") == "active" and data.get("plan") == "pro"
 
 
 
@@ -236,7 +236,14 @@ async def start_game(call: CallbackQuery, state: FSMContext):
         headers=headers,
     )
     if resp.status_code != 201:
-        await call.answer("Ошибка истории", show_alert=True)
+        if resp.status_code == 403:
+            await call.message.answer(
+                "Создай собственную историю в веб-приложении",
+                reply_markup=open_app_keyboard(settings.bots.web_url),
+            )
+            await state.clear()
+        else:
+            await call.answer("Ошибка истории", show_alert=True)
         return
     story_id = resp.json()["id"]
     resp = await http_client.post(

--- a/highway/src/api/payments/router.py
+++ b/highway/src/api/payments/router.py
@@ -57,8 +57,8 @@ async def subscription_status(
     )
     sub = res.scalars().first()
     if not sub:
-        return {"status": "canceled"}
-    return {"status": sub.status}
+        return {"status": "canceled", "plan": "free"}
+    return {"status": sub.status, "plan": sub.plan}
 
 
 @router.post("/subscription/change-plan")


### PR DESCRIPTION
## Summary
- handle incomplete story_frame data when starting sessions from presets
- include plan information in subscription status endpoint
- verify subscription plan on the bot before allowing custom stories
- show proper message when a non-pro user tries to start a custom story

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bbfa767448328838a9bdd1e9a70c1