### PR TITLE
feat: add multilingual support

### DIFF
--- a/bot/keyboards/inline.py
+++ b/bot/keyboards/inline.py
@@ -5,6 +5,8 @@ from typing import Iterable
 from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton, WebAppInfo
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 
+from utils.i18n import t
+
 
 def example_keyboard() -> InlineKeyboardMarkup:
     """Return a demo inline keyboard used for tests."""
@@ -16,25 +18,29 @@ def example_keyboard() -> InlineKeyboardMarkup:
     return kb.as_markup()
 
 
-def setup_keyboard() -> InlineKeyboardMarkup:
+def setup_keyboard(lang: str) -> InlineKeyboardMarkup:
     """Keyboard for the game setup step."""
     kb = InlineKeyboardBuilder()
-    kb.button(text="Setting", callback_data="edit:world_desc")
-    kb.button(text="Char Name", callback_data="edit:char_name")
-    kb.button(text="Char Age", callback_data="edit:char_age")
-    kb.button(text="Char Background", callback_data="edit:char_background")
-    kb.button(text="Char Personality", callback_data="edit:char_personality")
-    kb.button(text="Genre", callback_data="edit:genre")
-    kb.button(text="Начать игру", callback_data="start_game")
+    kb.button(text=t(lang, "setup_setting"), callback_data="edit:world_desc")
+    kb.button(text=t(lang, "setup_char_name"), callback_data="edit:char_name")
+    kb.button(text=t(lang, "setup_char_age"), callback_data="edit:char_age")
+    kb.button(
+        text=t(lang, "setup_char_background"), callback_data="edit:char_background"
+    )
+    kb.button(
+        text=t(lang, "setup_char_personality"), callback_data="edit:char_personality"
+    )
+    kb.button(text=t(lang, "setup_genre"), callback_data="edit:genre")
+    kb.button(text=t(lang, "start_game"), callback_data="start_game")
     kb.adjust(2, 2, 2, 1)
     return kb.as_markup()
 
 
-def cancel_keyboard() -> InlineKeyboardMarkup:
+def cancel_keyboard(lang: str) -> InlineKeyboardMarkup:
     """Keyboard with a single cancel button."""
 
     kb = InlineKeyboardBuilder()
-    kb.button(text="Отмена", callback_data="cancel")
+    kb.button(text=t(lang, "cancel"), callback_data="cancel")
     kb.adjust(1)
     return kb.as_markup()
 
@@ -68,16 +74,25 @@ def language_keyboard() -> InlineKeyboardMarkup:
     return kb.as_markup()
 
 
-def stories_keyboard(stories: Iterable[dict], web_url: str) -> InlineKeyboardMarkup:
+def stories_keyboard(stories: Iterable[dict], web_url: str, lang: str) -> InlineKeyboardMarkup:
     kb = InlineKeyboardBuilder()
     for story in stories:
         kb.button(text=story.get("title"), callback_data=f"preset:{story['id']}")
     kb.adjust(2)
-    kb.row(InlineKeyboardButton(text="✨ Откройте все истории", web_app=WebAppInfo(url=web_url)))
+    kb.row(
+        InlineKeyboardButton(
+            text=t(lang, "open_all_stories"),
+            web_app=WebAppInfo(url=web_url),
+        )
+    )
     return kb.as_markup()
 
 
-def open_app_keyboard(web_url: str) -> InlineKeyboardMarkup:
+def open_app_keyboard(web_url: str, lang: str) -> InlineKeyboardMarkup:
     kb = InlineKeyboardBuilder()
-    kb.row(InlineKeyboardButton(text="✨ Откройте веб-приложение", web_app=WebAppInfo(url=web_url)))
+    kb.row(
+        InlineKeyboardButton(
+            text=t(lang, "open_web_app"), web_app=WebAppInfo(url=web_url)
+        )
+    )
     return kb.as_markup()

--- a/bot/utils/commands.py
+++ b/bot/utils/commands.py
@@ -5,9 +5,17 @@ from aiogram.types import BotCommand, BotCommandScopeDefault
 
 
 async def set_commands(bot: Bot) -> None:
-    """Register default commands for the bot."""
+    """Register default commands for the bot in all supported languages."""
 
-    commands = [
+    commands_en = [
+        BotCommand(command="start", description="Start"),
+        BotCommand(command="my_game", description="Create game"),
+        BotCommand(command="my_games", description="My games"),
+        BotCommand(command="end_game", description="End game"),
+        BotCommand(command="help", description="Help"),
+    ]
+
+    commands_ru = [
         BotCommand(command="start", description="Регистрация"),
         BotCommand(command="my_game", description="Создать игру"),
         BotCommand(command="my_games", description="Мои игры"),
@@ -15,4 +23,5 @@ async def set_commands(bot: Bot) -> None:
         BotCommand(command="help", description="Помощь"),
     ]
 
-    await bot.set_my_commands(commands, BotCommandScopeDefault())
+    await bot.set_my_commands(commands_en, BotCommandScopeDefault(), language_code="en")
+    await bot.set_my_commands(commands_ru, BotCommandScopeDefault(), language_code="ru")

--- a/bot/utils/i18n.py
+++ b/bot/utils/i18n.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+TRANSLATIONS = {
+    "en": {
+        "choose_language": "Choose your language",
+        "registration_failed": "Failed to register",
+        "start_welcome": "👋 Hello, <b>{name}</b>!\nWelcome to <b>Immersia</b>",
+        "help_message": (
+            "ℹ️ <b>Help</b>\n\n"
+            "<b>/new_game</b> — create a new game\n"
+            "<b>/my_games</b> — list your active games\n"
+            "<b>/end_game</b> — finish current session\n"
+            "<b>/help</b> — show this message"
+        ),
+        "no_stories": "No available stories",
+        "choose_story": "Choose your story:",
+        "open_all_stories": "✨ Open all stories",
+        "open_web_app": "✨ Open web app",
+        "create_story_webapp": "Create your own story in the web app",
+        "setup_setting": "Setting",
+        "setup_char_name": "Char Name",
+        "setup_char_age": "Char Age",
+        "setup_char_background": "Char Background",
+        "setup_char_personality": "Char Personality",
+        "setup_genre": "Genre",
+        "start_game": "Start game",
+        "cancel": "Cancel",
+        "enter_setting_desc": "Enter setting description",
+        "enter_char_name": "Enter character name",
+        "enter_char_age": "Enter character age",
+        "enter_char_background": "Enter character background",
+        "enter_char_personality": "Enter character personality",
+        "enter_genre": "Enter genre",
+        "error_story": "Story error",
+        "error_session": "Session error",
+        "error_scene": "Scene error",
+        "error_generic": "Error",
+        "you_chose": "You chose: {choice}",
+        "no_active_games": "You have no active games yet. Use /new_game to start.",
+        "resume_game_prompt": "You can continue one of your current games:",
+        "no_active_game": "No active game",
+        "session_finished": "Session finished",
+        "label_setting_desc": "Setting Description",
+        "label_char_name": "Character Name",
+        "label_char_age": "Character Age",
+        "label_char_background": "Character Background",
+        "label_char_personality": "Character Personality",
+        "label_genre": "Genre",
+        "genre_Horror": "Horror",
+        "genre_Romantic": "Romantic",
+        "genre_Adventure": "Adventure",
+        "genre_Fantasy": "Fantasy",
+        "genre_Sci-Fi": "Sci-Fi",
+    },
+    "ru": {
+        "choose_language": "Выберите язык",
+        "registration_failed": "Не удалось зарегистрироваться",
+        "start_welcome": "👋 Привет, <b>{name}</b>!\nДобро пожаловать в <b>Immersia</b>",
+        "help_message": (
+            "ℹ️ <b>Помощь</b>\n\n"
+            "<b>/new_game</b> — создать новую игру\n"
+            "<b>/my_games</b> — список ваших активных игр\n"
+            "<b>/end_game</b> — завершить текущую сессию\n"
+            "<b>/help</b> — показать это сообщение"
+        ),
+        "no_stories": "Нет доступных историй",
+        "choose_story": "Выберите вашу историю:",
+        "open_all_stories": "✨ Откройте все истории",
+        "open_web_app": "✨ Откройте веб-приложение",
+        "create_story_webapp": "Создай собственную историю в веб-приложении",
+        "setup_setting": "Сеттинг",
+        "setup_char_name": "Имя персонажа",
+        "setup_char_age": "Возраст персонажа",
+        "setup_char_background": "Предыстория",
+        "setup_char_personality": "Характер",
+        "setup_genre": "Жанр",
+        "start_game": "Начать игру",
+        "cancel": "Отмена",
+        "enter_setting_desc": "Введите описание сеттинга",
+        "enter_char_name": "Введите имя персонажа",
+        "enter_char_age": "Введите возраст персонажа",
+        "enter_char_background": "Введите предысторию персонажа",
+        "enter_char_personality": "Введите характер персонажа",
+        "enter_genre": "Введите жанр",
+        "error_story": "Ошибка истории",
+        "error_session": "Ошибка сессии",
+        "error_scene": "Ошибка сцены",
+        "error_generic": "Ошибка",
+        "you_chose": "Вы выбрали: {choice}",
+        "no_active_games": "У вас пока нет активных игр. Используйте /new_game, чтобы начать.",
+        "resume_game_prompt": "Вы можете продолжить одну из текущих игр:",
+        "no_active_game": "Нет активной игры",
+        "session_finished": "Сессия завершена",
+        "label_setting_desc": "Описание сеттинга",
+        "label_char_name": "Имя персонажа",
+        "label_char_age": "Возраст персонажа",
+        "label_char_background": "Предыстория персонажа",
+        "label_char_personality": "Характер персонажа",
+        "label_genre": "Жанр",
+        "genre_Horror": "Ужасы",
+        "genre_Romantic": "Романтика",
+        "genre_Adventure": "Приключение",
+        "genre_Fantasy": "Фэнтези",
+        "genre_Sci-Fi": "Научная фантастика",
+    },
+}
+
+DEFAULT_LANG = "en"
+
+
+def t(lang: str, key: str, **kwargs) -> str:
+    lang_dict = TRANSLATIONS.get(lang, TRANSLATIONS[DEFAULT_LANG])
+    text = lang_dict.get(key) or TRANSLATIONS[DEFAULT_LANG].get(key, "")
+    return text.format(**kwargs)
+
+
+USER_LANG: dict[int, str] = {}
+
+
+async def get_user_language(uid: int) -> str:
+    if uid in USER_LANG:
+        return USER_LANG[uid]
+    import httpx
+    from settings import settings
+
+    client = httpx.AsyncClient(base_url=settings.bots.app_url, timeout=10.0)
+    resp = await client.get("/api/v1/users/me/", headers={"X-User-Id": str(uid)})
+    if resp.status_code == 200:
+        lang = resp.json().get("language") or DEFAULT_LANG
+    else:
+        lang = DEFAULT_LANG
+    USER_LANG[uid] = lang
+    await client.aclose()
+    return lang
+
+
+def set_user_language(uid: int, lang: str) -> None:
+    USER_LANG[uid] = lang

--- a/bot/utils/presets.py
+++ b/bot/utils/presets.py
@@ -1,14 +1,15 @@
 from keyboards.inline import stories_keyboard
 from settings import settings
+from utils.i18n import t
 import httpx
 
 http_client = httpx.AsyncClient(base_url=settings.bots.app_url, timeout=10.0)
 
 
-async def show_presets(chat_id: int, bot) -> None:
+async def show_presets(chat_id: int, bot, lang: str) -> None:
     resp = await http_client.get("/api/v1/stories/preset/")
     if resp.status_code != 200:
-        await bot.send_message(chat_id, "Нет доступных историй")
+        await bot.send_message(chat_id, t(lang, "no_stories"))
         return
     stories = resp.json()
     emojis = {
@@ -18,11 +19,12 @@ async def show_presets(chat_id: int, bot) -> None:
         "Fantasy": "🧙",
         "Sci-Fi": "🤖",
     }
-    lines = ["Выберите вашу историю:"]
+    lines = [t(lang, "choose_story")]
     for s in stories:
         emoji = emojis.get(s.get("genre"), "🎲")
-        lines.append(f"{emoji} [{s.get('genre')}] {s.get('title')}")
+        genre = t(lang, f"genre_{s.get('genre')}") or s.get("genre")
+        lines.append(f"{emoji} [{genre}] {s.get('title')}")
     text = "\n".join(lines)
-    kb = stories_keyboard(stories, settings.bots.web_url)
+    kb = stories_keyboard(stories, settings.bots.web_url, lang)
     await bot.send_message(chat_id, text, reply_markup=kb)
 

--- a/gradio-legacy/src/agent/llm_graph.py
+++ b/gradio-legacy/src/agent/llm_graph.py
@@ -31,6 +31,7 @@ class GraphState:
     choice_text: Optional[str] = None
     scene: Optional[Dict[str, Any]] = None
     ending: Optional[Dict[str, Any]] = None
+    language: Optional[str] = None
 
 
 async def node_entry(state: GraphState) -> GraphState:
@@ -55,6 +56,7 @@ async def node_init_game(state: GraphState) -> GraphState:
             "setting": state.setting,
             "character": state.character,
             "genre": state.genre,
+            "language": state.language,
         }
     )
     first_scene = await generate_scene.ainvoke(

--- a/gradio-legacy/src/agent/models.py
+++ b/gradio-legacy/src/agent/models.py
@@ -31,6 +31,7 @@ class StoryFrame(BaseModel):
     setting: str
     character: Dict[str, str]
     genre: str
+    language: str = "en"
 
 
 class StoryFrameLLM(BaseModel):
@@ -102,3 +103,4 @@ class UserState(BaseModel):
     user_choices: List[UserChoice] = Field(default_factory=list)
     ending: Optional[Ending] = None
     assets: Dict[str, str] = Field(default_factory=dict)
+    language: str = "en"

--- a/gradio-legacy/src/agent/prompts.py
+++ b/gradio-legacy/src/agent/prompts.py
@@ -10,7 +10,7 @@ Return ONLY a JSON object with:
 - milestones: 2-4 key events (id, description)
 - endings: good/bad endings (id, type, condition, description)
 
-Translate the lore, goal, milestones and endings to the language which is used in the game and setting description.
+Translate the lore, goal, milestones and endings into {language}.
 """
 
 GAME_STATE_PROMPT = """
@@ -31,7 +31,7 @@ Game response to user's action: {scene_description}
 
 SCENE_PROMPT = """You are an AI agent for a visual novel game. 
 Your role is to process incoming data and generate the next scene description and choices.
-Translate the scene description and choices into a language which is used in the Game Settings.
+Translate the scene description and choices into {language}.
 
 ---Game Settings START---
 Lore: {lore}

--- a/highway/src/api/scenes/scene_service.py
+++ b/highway/src/api/scenes/scene_service.py
@@ -30,6 +30,9 @@ async def create_and_store_scene(
 ) -> Scene:
     user_hash = str(session.id)
     state = await get_user_state(user_hash)
+    if not state.language:
+        await db.refresh(session, ["user"])
+        state.language = session.user.language or "en"
     if not state.story_frame:
         if session.story_frame:
             sf_data = dict(session.story_frame)
@@ -41,6 +44,7 @@ async def create_and_store_scene(
                 sf_data.setdefault("setting", session.story.world.world_desc)
                 sf_data.setdefault("character", session.story.character or {})
                 sf_data.setdefault("genre", session.story.genre)
+            sf_data.setdefault("language", state.language)
             state.story_frame = StoryFrame(**sf_data)
         elif session.story and session.story.story_frame:
             await db.refresh(session.story, ["world"])
@@ -48,6 +52,7 @@ async def create_and_store_scene(
             sf_data.setdefault("setting", session.story.world.world_desc)
             sf_data.setdefault("character", session.story.character or {})
             sf_data.setdefault("genre", session.story.genre)
+            sf_data.setdefault("language", state.language)
             state.story_frame = StoryFrame(**sf_data)
 
     if not state.user_choices:
@@ -80,6 +85,7 @@ async def create_and_store_scene(
                 setting=world.world_desc,
                 character=story.character or {},
                 genre=story.genre,
+                language=state.language,
             )
             state.story_frame = story_frame
         else:

--- a/highway/src/game/agent/models.py
+++ b/highway/src/game/agent/models.py
@@ -31,6 +31,7 @@ class StoryFrame(BaseModel):
     setting: str
     character: Dict[str, str]
     genre: str
+    language: str = "en"
 
 
 class StoryFrameLLM(BaseModel):
@@ -107,3 +108,4 @@ class UserState(BaseModel):
     ending: Optional[Ending] = None
     last_image_prompt: Optional[str] = None
     assets: Dict[str, str] = Field(default_factory=dict)
+    language: str = "en"

--- a/highway/src/game/agent/prompts.py
+++ b/highway/src/game/agent/prompts.py
@@ -10,7 +10,7 @@ Return ONLY a JSON object with:
 - milestones: 2-4 key events (id, description)
 - endings: good/bad endings (id, type, condition, description)
 
-Translate the lore, goal, milestones and endings to the language which is used in the game and setting description.
+Translate the lore, goal, milestones and endings into {language}.
 """
 
 GAME_STATE_PROMPT = """
@@ -32,7 +32,7 @@ Game response to user's action: {scene_description}
 
 SCENE_PROMPT = """You are an AI agent for a visual novel game. 
 Your role is to process incoming data and generate the next scene description and choices.
-Translate the scene description and choices into a language which is used in the Game Settings.
+Translate the scene description and choices into {language}.
 
 ---Game Settings START---
 Lore: {lore}

--- a/highway/src/game/agent/tools.py
+++ b/highway/src/game/agent/tools.py
@@ -30,6 +30,7 @@ async def generate_story_frame(
     setting: Annotated[str, "Game world setting"],
     character: Annotated[Dict[str, str], "Character info"],
     genre: Annotated[str, "Genre"],
+    language: Annotated[str, "Output language"],
 ) -> StoryFrame:
     """Create the initial story frame and store it in user state."""
     llm = create_llm().with_structured_output(StoryFrameLLM)
@@ -37,6 +38,7 @@ async def generate_story_frame(
         setting=setting,
         character=character,
         genre=genre,
+        language=language,
     )
     resp: StoryFrameLLM = await with_retries(lambda: llm.ainvoke(prompt))
     story_frame = StoryFrame(
@@ -47,6 +49,7 @@ async def generate_story_frame(
         setting=setting,
         character=character,
         genre=genre,
+        language=language,
     )
     return story_frame
 
@@ -121,6 +124,7 @@ async def generate_scene(
         endings=",".join(e.id for e in state.story_frame.endings),
         history="; ".join(f"{c.scene_id}:{c.choice_text}" for c in state.user_choices),
         last_choice=last_choice,
+        language=state.language,
     )
     resp: SceneLLM = await with_retries(lambda: llm.ainvoke(prompt))
     return resp


### PR DESCRIPTION
## Summary
- add i18n utilities and per-user language storage for bot
- localize bot interface, keyboards, and game flow for English and Russian
- carry language through backend prompts and state for multilingual scene generation

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_688e1d5710308328a2d776ed56bf06c2