### PR TITLE
Fix missing auth header in bot user language request

### DIFF
--- a/bot/utils/i18n.py
+++ b/bot/utils/i18n.py
@@ -123,8 +123,15 @@ async def get_user_language(uid: int) -> str:
     import httpx
     from settings import settings
 
-    client = httpx.AsyncClient(base_url=settings.bots.app_url, timeout=10.0)
-    resp = await client.get("/api/v1/users/me/", headers={"X-User-Id": str(uid)})
+    client = httpx.AsyncClient(
+        base_url=settings.bots.app_url,
+        timeout=10.0,
+        headers={"X-Server-Auth": settings.bots.server_auth_token.get_secret_value()},
+    )
+    resp = await client.get(
+        "/api/v1/users/me/",
+        headers={"X-User-Id": str(uid)},
+    )
     if resp.status_code == 200:
         lang = resp.json().get("language") or DEFAULT_LANG
     else:


### PR DESCRIPTION
## Summary
- include server auth token when fetching user language

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_688e2b1913fc83289ddeec911f296923