### PR TITLE
Ensure scene generation respects user language

### DIFF
--- a/highway/src/api/scenes/scene_service.py
+++ b/highway/src/api/scenes/scene_service.py
@@ -31,9 +31,8 @@ async def create_and_store_scene(
 ) -> Scene:
     user_hash = str(session.id)
     state = await get_user_state(user_hash)
-    if not state.language:
-        await db.refresh(session, ["user"])
-        state.language = session.user.language or "en"
+    await db.refresh(session, ["user"])
+    state.language = session.user.language or state.language or "en"
     if not state.story_frame:
         if session.story_frame:
             sf_data = dict(session.story_frame)


### PR DESCRIPTION
## Summary
- Fix language selection in scene generation so user language overrides default

## Testing
- `TG_BOT_TOKEN=x SERVER_AUTH_TOKEN=x DATABASE_URL=sqlite+aiosqlite:///test.db PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688e7a2d51d8832895fc70fcb7a77648