### PR TITLE
Fix story title translation handling

### DIFF
--- a/bot/keyboards/inline.py
+++ b/bot/keyboards/inline.py
@@ -80,7 +80,10 @@ def language_keyboard() -> InlineKeyboardMarkup:
 def stories_keyboard(stories: Iterable[dict], web_url: str, lang: str) -> InlineKeyboardMarkup:
     kb = InlineKeyboardBuilder()
     for story in stories:
-        kb.button(text=story.get("title"), callback_data=f"preset:{story['id']}")
+        title = story.get("title")
+        if isinstance(title, dict):
+            title = title.get(lang) or title.get("en") or next(iter(title.values()), "")
+        kb.button(text=title, callback_data=f"preset:{story['id']}")
     kb.adjust(2)
     kb.row(
         InlineKeyboardButton(

--- a/bot/utils/presets.py
+++ b/bot/utils/presets.py
@@ -23,7 +23,10 @@ async def show_presets(chat_id: int, bot, lang: str) -> None:
     for s in stories:
         emoji = emojis.get(s.get("genre"), "🎲")
         genre = t(lang, f"genre_{s.get('genre')}") or s.get("genre")
-        lines.append(f"{emoji} [{genre}] {s.get('title')}")
+        title = s.get("title")
+        if isinstance(title, dict):
+            title = title.get(lang) or title.get("en") or next(iter(title.values()), "")
+        lines.append(f"{emoji} [{genre}] {title}")
     text = "\n".join(lines)
     kb = stories_keyboard(stories, settings.bots.web_url, lang)
     await bot.send_message(chat_id, text, reply_markup=kb)


### PR DESCRIPTION
## Summary
- fix story preset rendering to pick localized title strings
- update preset keyboard to show translated titles

## Testing
- `pip install aiosqlite -q`
- `TG_BOT_TOKEN=1 SERVER_AUTH_TOKEN=1 DATABASE_URL=sqlite+aiosqlite:///test.db PYTHONPATH=highway pytest -q highway/tests/test_main.py`


------
https://chatgpt.com/codex/tasks/task_e_688ea1da18a083288d518cba941b3fee