### PR TITLE
feat: refresh presets and improve story covers

### DIFF
--- a/bot/utils/presets.py
+++ b/bot/utils/presets.py
@@ -50,7 +50,13 @@ async def show_presets(chat_id: int, bot, lang: str) -> None:
         title = s.get("title")
         if isinstance(title, dict):
             title = title.get(lang) or title.get("en") or next(iter(title.values()), "")
-        lines.append(f"{emoji} [{genre}] {title}")
+        desc = s.get("story_desc")
+        if isinstance(desc, dict):
+            desc = desc.get(lang) or desc.get("en") or next(iter(desc.values()), "")
+        entry = f"{emoji} [{genre}] {title}"
+        if desc:
+            entry = f"{entry}\n{desc}"
+        lines.append(entry)
     text = "\n\n".join(lines)
     kb = stories_keyboard(stories, settings.bots.web_url, lang)
     await bot.send_message(chat_id, text, reply_markup=kb, parse_mode="HTML")

--- a/highway/src/utils/import_stories_on_startup.py
+++ b/highway/src/utils/import_stories_on_startup.py
@@ -1,5 +1,6 @@
 from src.core.database import AsyncSessionLocal
 from src.models.world import World
+from src.models.story import Story
 from src.api.stories.router import _import_presets
 from pathlib import Path
 import json
@@ -13,8 +14,9 @@ logger = logging.getLogger(__name__)
 async def import_stories_on_startup():
     # Automatically import preset worlds and stories on first startup if none exist
     async with AsyncSessionLocal() as session:
-        res = await session.execute(select(World).where(World.is_preset.is_(True)))
-        if res.scalars().first() is None:
+        world_res = await session.execute(select(World.id).limit(1))
+        story_res = await session.execute(select(Story.id).limit(1))
+        if world_res.scalars().first() is None and story_res.scalars().first() is None:
             presets_path = Path(settings.presets_file_path)
             if not presets_path.is_absolute():
                 presets_path = Path(__file__).resolve().parent.parent / presets_path

--- a/miniapp/src/api/stories.ts
+++ b/miniapp/src/api/stories.ts
@@ -14,8 +14,8 @@ export interface StoryDTO {
 export interface Story {
   id: string;
   title: string;
-  description: string;
-  imageUrl: string;
+  description?: string;
+  imageUrl?: string;
 }
 
 export function useStories(realmId: string) {
@@ -28,13 +28,17 @@ export function useStories(realmId: string) {
 }
 
 export async function getStories(realmId: string, lang: string = "en"): Promise<Story[]> {
-  return fetch(`${API_URL}/api/v1/worlds/${realmId}/stories/?lang=${lang}`).then((res) => res.json()).then((data) => data.map((item: StoryDTO) => ({
-    id: item.id,
-    title: item.title,
-    description: item.story_desc,
-    imageUrl: item.image_url,
-  })));
-} 
+  return fetch(`${API_URL}/api/v1/worlds/${realmId}/stories/?lang=${lang}`)
+    .then((res) => res.json())
+    .then((data) =>
+      data.map((item: StoryDTO) => ({
+        id: item.id,
+        title: item.title,
+        description: item.story_desc,
+        imageUrl: item.image_url,
+      }))
+    );
+}
 
 export async function startStory(storyId: string) {
   return fetch(`${API_URL}/bot/api/v1/stories/start/${storyId}/`, {

--- a/miniapp/src/components/StoryCard/StoryCard.tsx
+++ b/miniapp/src/components/StoryCard/StoryCard.tsx
@@ -6,7 +6,7 @@ interface StoryCardProps {
   id: string;
   title: string;
   description?: string;
-  imageUrl: string;
+  imageUrl?: string;
   onClick?: (storyId: string) => void;
   className?: string;
 }


### PR DESCRIPTION
## Summary
- replace existing preset worlds and stories when uploading new preset JSON
- auto-import presets on startup if database is empty
- show story descriptions in Telegram bot preset list
- handle optional story images in miniapp API and cards

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src')*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: react-refresh/only-export-components in button.tsx)*
- `npx eslint src/api/stories.ts src/components/StoryCard/StoryCard.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689279614970832895f1491c4559b3d1