### PR TITLE
Improve story and image prompts for clearer branching

### DIFF
--- a/highway/src/game/agent/image_agent.py
+++ b/highway/src/game/agent/image_agent.py
@@ -10,12 +10,15 @@ from src.game.agent.models import UserState
 logger = logging.getLogger(__name__)
 
 
-IMAGE_GENERATION_SYSTEM_PROMPT = """You are an AI agent for a visual novel game.
-Your role is to process an incoming scene description and determine if the visual scene needs to change.
-If it does, you will generate a new `scene_description`. This `scene_description` MUST BE a highly detailed image prompt, specifically engineered for an AI image generation model.
+IMAGE_GENERATION_SYSTEM_PROMPT = """You are an image director for a visual novel.
+Read the incoming scene data and decide if the visual scene must change.
+Return JSON {"change_scene": bool, "scene_description": str|None}. If
+`change_scene` is true, `scene_description` must be a fresh, detailed
+prompt for an image-generation model.
 
-**Guidelines for Crafting the Image Prompt (for `scene_description` field):**
-When generating the image prompt, ensure it's detailed and considers the following aspects. IMPORTANT: The final description must be written objectively, with NO first-person perspective or references (e.g., "I", "me", "my", "in front of me"). Describe the scene as though captured in a photograph, observing only what is visible on screen.
+**Guidelines for Crafting `scene_description`**
+Write objectively with NO first-person references. Describe only what is
+visible on screen, as if framed in a photograph.
 
 1.  **Subject & Focus:**
     *   What is the primary subject or point of interest directly in the character's view?
@@ -55,9 +58,11 @@ When generating the image prompt, ensure it's detailed and considers the followi
 "Through the cockpit window of a futuristic hovercar, a sprawling neon-lit cyberpunk city stretches out under a stormy, rain-lashed sky. Rain streaks across the glass. The hum of the engine is palpable. Photorealistic, Blade Runner style. Cool blue and vibrant pink neon palette."
 
 
-*IMPORTANT*: Please pay attention to last image description and make sure you reuse the same visual style and elements when updating the image in order to avoid generating a completely different scene.
+*IMPORTANT*: Reuse key visual style elements from the previous image
+description to preserve continuity.
 
-If you are describing other character and the player is interacting with them, make sure to prompt this character to look into the camera.
+If the player is interacting with another character, prompt that
+character to look into the camera.
 """
 
 

--- a/highway/src/game/agent/prompts.py
+++ b/highway/src/game/agent/prompts.py
@@ -1,16 +1,19 @@
 STORY_FRAME_PROMPT = """
-You are a narrative game designer. Use the player data below to
-create a story frame for an interactive adventure.
+You are an experienced narrative designer. Use the player profile below
+to create a concise framework for an interactive adventure that moves
+at a brisk pace.
+
 Setting: {setting}
 Character: {character}
 Genre: {genre}
+
 Return ONLY a JSON object with:
-- lore: brief world description
-- goal: main player objective
-- milestones: 2-4 key events (id, description)
+- lore: 2-3 sentence world description
+- goal: clear main player objective
+- milestones: 2-4 escalating key events (id, description)
 - endings: good/bad endings (id, type, condition, description)
 
-Translate the lore, goal, milestones and endings into {language}.
+All returned text must be in {language}.
 """
 
 GAME_STATE_PROMPT = """
@@ -31,8 +34,11 @@ Last choice: {last_choice}
 Game response to user's action: {scene_description}
 """
 
-SCENE_PROMPT = """You are an AI agent for a visual novel game. 
-Your role is to process incoming data and generate the next scene description and choices.
+SCENE_PROMPT = """You are an AI writer for a branching visual novel.
+Process the data below and craft the next scene and two meaningful
+player choices. The story must react to the player's last action and
+always push the plot forward with new information or consequences.
+
 Translate the scene description and choices into {language}.
 
 ---Game Settings START---
@@ -48,10 +54,15 @@ History: {history}
 Last choice: {last_choice}
 ---User's actions END---
 
-The scene description must be 2-5 sentences and no more than 150 words.
-Each choice text must be concise, up to 12 words.
+Guidelines for the scene:
+- 2-4 sentences, max 120 words, no filler or repetition.
+- Show a noticeable change in stakes, location, or knowledge.
+- If the last choice is absurd or off-plot, respond in-world and gently
+  steer back toward the main narrative.
+- Each choice text must be ≤12 words and lead to distinct outcomes.
+
 Respond ONLY with JSON containing:
-- description: current scene description based on the user's actions and the game settings
+- description: scene description
 - choices: exactly two dicts {{"text": ..., "next_scene_short_desc": ...}}
 """
 


### PR DESCRIPTION
## Summary
- Refine story frame prompt to create faster-paced adventure setups and enforce language selection
- Rewrite scene generation prompt to advance the plot, avoid repetition and produce two meaningful choices
- Clarify image generation system prompt and require JSON response with continuity hints

## Testing
- `python -m py_compile highway/src/game/agent/prompts.py highway/src/game/agent/image_agent.py`
- `python - <<'PY'
import sys
sys.path.append('highway')
from src.game.agent.prompts import SCENE_PROMPT
prompt=SCENE_PROMPT.format(lore="Ancient coastal town shrouded in fog",goal="Uncover the truth behind disappearances",milestones="m1:Reach the docks;m2:Discover hidden shrine",endings="good:free the spirits;bad:succumb to curse",npc_characters="Fisherman: weathered man in yellow coat",history="",last_choice="Начало",language="ru")
print(prompt)
PY`
- Attempted to load image agent for end-to-end test but failed due to missing runtime configuration

------
https://chatgpt.com/codex/tasks/task_e_6894804066ec832893eb94d84e2c0ebc