### PR TITLE
Fix ending description retrieval

### DIFF
--- a/gradio-legacy/src/agent/tools.py
+++ b/gradio-legacy/src/agent/tools.py
@@ -171,7 +171,13 @@ async def check_ending(
     )
     resp: EndingCheckResult = await with_retries(lambda: llm.ainvoke(prompt))
     if resp.ending_reached and resp.ending:
-        state.ending = resp.ending
+        # Look up the full ending details from the story frame so that the
+        # description returned to the player matches the original design.
+        ending = next(
+            (e for e in state.story_frame.endings if e.id == resp.ending.id),
+            resp.ending,
+        )
+        state.ending = ending
         await set_user_state(user_hash, state)
-        return {"ending_reached": True, "ending": resp.ending.dict()}
+        return {"ending_reached": True, "ending": ending.dict()}
     return {"ending_reached": False}

--- a/highway/src/game/agent/tools.py
+++ b/highway/src/game/agent/tools.py
@@ -176,4 +176,14 @@ async def check_ending(
         endings=",".join(f"{e.id}:{e.condition}" for e in state.story_frame.endings),
     )
     resp: EndingCheckResult = await with_retries(lambda: llm.ainvoke(prompt))
+
+    if resp.ending_reached and resp.ending is not None:
+        # Use the ending definition from the original story frame so the
+        # description and other fields are accurate instead of the LLM's guess.
+        ending = next(
+            (e for e in state.story_frame.endings if e.id == resp.ending.id),
+            resp.ending,
+        )
+        resp.ending = ending
+
     return resp


### PR DESCRIPTION
## Summary
- ensure ending descriptions returned from `check_ending` come from the original story frame
- preserve accurate ending details when sending them to players

## Testing
- `TG_BOT_TOKEN=test SERVER_AUTH_TOKEN=test DATABASE_URL=sqlite+aiosqlite:///test.db PYTHONPATH=highway pytest`


------
https://chatgpt.com/codex/tasks/task_e_68949c009a4883289e0e71b550d4d0a5