### PR TITLE
Fix custom story session handling and persist generated story data

### DIFF
--- a/highway/src/models/story.py
+++ b/highway/src/models/story.py
@@ -27,7 +27,7 @@ class Story(Base):
     genre: Mapped[str | None] = mapped_column(Text, nullable=True)
     image_url: Mapped[str | None] = mapped_column(Text, nullable=True)
     character: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
-    visual_style: Mapped[str | None] = mapped_column(JSONB, nullable=True)
+    visual_style: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     npc_characters: Mapped[list[dict] | None] = mapped_column(JSONB, nullable=True)
     story_frame: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     is_public: Mapped[bool] = mapped_column(Boolean, default=False)


### PR DESCRIPTION
## Summary
- always start custom sessions from the latest user story to avoid mixed prompts
- save generated story frame, visual style and NPCs back to the story record
- validate choice text to prevent `None` actions during gameplay

## Testing
- `SERVER_AUTH_TOKEN=1 DATABASE_URL=sqlite+aiosqlite:///:memory: TG_BOT_TOKEN=1 PYTHONPATH=highway pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68951d9463348328b03898607ea6fa54