### PR TITLE
Ensure new stories respect input parameters

### DIFF
--- a/highway/src/api/scenes/scene_service.py
+++ b/highway/src/api/scenes/scene_service.py
@@ -108,14 +108,18 @@ async def create_and_store_scene(
 
     if order_num == 1 and not session.story_frame:
         if state.story_frame:
-            session.story_frame = state.story_frame.model_dump()
+            session.story_frame = state.story_frame.model_dump(
+                exclude={"visual_style", "npc_characters"}
+            )
             db.add(session)
             await db.commit()
             await db.refresh(session)
 
             # Persist generated story frame and related data to the Story
             if story:
-                story.story_frame = state.story_frame.model_dump()
+                story.story_frame = state.story_frame.model_dump(
+                    exclude={"visual_style", "npc_characters"}
+                )
                 if state.story_frame.visual_style:
                     current_style = story.visual_style or {}
                     if not isinstance(current_style, dict):

--- a/highway/src/api/stories/router.py
+++ b/highway/src/api/stories/router.py
@@ -17,7 +17,7 @@ from src.models.user import User
 from src.models.game_session import GameSession
 from src.models.scene import Scene
 from src.models.choice import Choice
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 router = APIRouter(prefix="/api/v1", tags=["stories"])
 
@@ -38,7 +38,7 @@ class StoryCreate(BaseModel):
     visual_style: dict | None = None
     npc_characters: list[dict] | None = None
     character: dict | None = None
-    story_frame: dict | None = None
+    story_frame: dict | None = Field(default=None, exclude=True)
     is_public: bool | None = None
     is_free: bool | None = None
 


### PR DESCRIPTION
## Summary
- ignore incoming `story_frame` when creating stories so story frames are generated from user parameters
- store story frames without `visual_style` and NPCs; keep them in dedicated fields

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_6895279c39c48328bcee13cb8461ba03