### PR TITLE
Fix payment confirmation to restore energy updates

### DIFF
--- a/bot/handlers/game.py
+++ b/bot/handlers/game.py
@@ -504,9 +504,20 @@ async def make_choice(call: CallbackQuery, state: FSMContext):
     )
 
 
-@router.message(GamePlay.waiting_choice)
+@router.message(
+    GamePlay.waiting_choice,
+    F.text,
+    ~F.text.startswith("/"),
+    ~F.invoice,
+    ~F.successful_payment,
+)
 async def choice_text(message: Message, state: FSMContext):
-    """Handle text choice input during gameplay."""
+    """Handle text choice input during gameplay.
+
+    The extra filters ensure that payment- or command-related messages are
+    processed by their dedicated handlers rather than being interpreted as a
+    story choice when the user is in ``waiting_choice`` state.
+    """
     lang = await get_user_language(message.from_user.id)
     choice = message.text
     data = await state.get_data()

--- a/bot/handlers/payments.py
+++ b/bot/handlers/payments.py
@@ -12,6 +12,9 @@ router = Router()
 http_client = httpx.AsyncClient(
     base_url=settings.bots.app_url,
     timeout=httpx.Timeout(60.0),
+    headers={
+        "X-Server-Auth": settings.bots.server_auth_token.get_secret_value()
+    },
 )
 
 


### PR DESCRIPTION
## Summary
- ensure payment API requests include server auth token so purchases credit energy and notify service chat
- restrict game choice handler to text-only messages so commands and payments work even with zero energy

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_68964a0e9610832888ae2b73f55cb046