### PR TITLE
fix: only list preset worlds

### DIFF
--- a/highway/src/api/worlds/router.py
+++ b/highway/src/api/worlds/router.py
@@ -35,7 +35,7 @@ class WorldCreate(BaseModel):
 async def list_worlds(
     lang: str = "ru", db: AsyncSession = Depends(get_session)
 ) -> list[WorldOut]:
-    res = await db.execute(select(World))
+    res = await db.execute(select(World).where(World.is_preset.is_(True)))
     worlds = list(res.scalars())
     return [
         WorldOut(


### PR DESCRIPTION
## Summary
- filter world listing to return only preset worlds

## Testing
- `TG_BOT_TOKEN=dummy SERVER_AUTH_TOKEN=dummy DATABASE_URL=sqlite+aiosqlite:///test.db PYTHONPATH=$(pwd)/highway pytest highway/tests/test_main.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689791a9d7b08328ab7c6fafb8f80ac8